### PR TITLE
fix: correct ghostty scrollback config key

### DIFF
--- a/dot-claude/plugins/known_marketplaces.json
+++ b/dot-claude/plugins/known_marketplaces.json
@@ -5,7 +5,7 @@
       "repo": "anthropics/claude-plugins-official"
     },
     "installLocation": "/Users/jarvis/.claude/plugins/marketplaces/claude-plugins-official",
-    "lastUpdated": "2026-03-10T16:16:55.491Z"
+    "lastUpdated": "2026-03-10T16:20:53.546Z"
   },
   "anthropic-agent-skills": {
     "source": {

--- a/ghostty/config
+++ b/ghostty/config
@@ -31,7 +31,7 @@ clipboard-paste-protection = false
 copy-on-select = true
 
 # Scrollback (tmux manages scrollback)
-scrollback-lines = 0
+scrollback-limit = 0
 
 # Shell (tmux manages everything)
 shell-integration = none


### PR DESCRIPTION
## Summary
- Replace unknown `scrollback-lines` with the correct `scrollback-limit` in ghostty config

## Test plan
- [ ] Reload Ghostty and verify no unknown config warnings