### PR TITLE
feat: gradient prompt character with ease-in fade

### DIFF
--- a/dot-claude/settings.json
+++ b/dot-claude/settings.json
@@ -157,5 +157,6 @@
         "@knip/mcp"
       ]
     }
-  }
+  },
+  "model": "sonnet"
 }

--- a/starship.toml
+++ b/starship.toml
@@ -23,8 +23,8 @@ shell = ["sh"]
 ignore_timeout = true
 
 [character]
-success_symbol = "[](fg:#D8DEE9)[     ](bg:#D8DEE9)[](fg:#D8DEE9)[❯](fg:#ECEFF4)"
-error_symbol = "[](fg:#BF616A)[     ](bg:#BF616A)[](fg:#BF616A)[❯](fg:#BF616A)"
+success_symbol = "[](fg:#D8DEE9)[](fg:#D8DEE9 bg:#D5DBE6)[](fg:#D5DBE6 bg:#CBD2DD)[](fg:#CBD2DD bg:#BCC2CE)[](fg:#BCC2CE bg:#A5ACB8)[](fg:#A5ACB8 bg:#89909D)[   ](bg:#89909D)[](fg:#89909D)"
+error_symbol = "[](fg:#BF616A)[     ](bg:#BF616A)[](fg:#BF616A)"
 
 [cmd_duration]
 disabled = true


### PR DESCRIPTION
## Summary
- Replaces the flat Snow Storm 1 pill + `❯` prompt character with a 6-stop ease-in quadratic gradient using powerline arrow glyphs as color transitions
- Gradient fades from `#D8DEE9` (Snow Storm 1) to `#89909D` (midpoint grey), keeping the prompt subtle against the Nord terminal background
- Sets default model to `sonnet` in `settings.json`

## Test plan
- [ ] Reload shell and verify new prompt gradient renders correctly
- [ ] Verify error symbol still shows red pill on failed commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)