### PR TITLE
feat: add Android/Rust tooling and simplify prompt identity cell

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -4,6 +4,9 @@ export MANPAGER="nvim +Man!"
 export LANG=en_US.UTF-8
 export LESS='-RFX'
 export RIPGREP_CONFIG_PATH="$HOME/.ripgreprc"
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export PATH="$PATH:$ANDROID_HOME/platform-tools"
 
 # Machine-local secrets (not in git)
 [[ -f ~/.secrets ]] && source ~/.secrets
@@ -106,8 +109,9 @@ zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
 setopt promptsubst
 source ~/dotFiles/theme.sh
 
-# _prompt_repo_dir -- renders CWD cell + repo/GH icon segment
-# CWD cell (Nord 1) always first. Repo segment follows in git repos with remote.
+# _prompt_repo_dir -- renders identity cell (repo OR CWD) + GH icon
+# Shows repo name (linked, underlined) if in GH repo, else CWD path.
+# Both use Snow Storm 1 bg. Repo wins when both exist.
 # Reads: GIT_REPO_NAME, GIT_REPO_HTTPS, GIT_PR_STATUS, GIT_PR_URL, GIT_IS_REPO
 function _prompt_repo_dir() {
   local _fg=$'%{\e[38;2;'   _bg=$'%{\e[48;2;'   _m=$'m%}'   _rst=$'%{\e[0m%}'
@@ -121,14 +125,12 @@ function _prompt_repo_dir() {
 
   # Color triplets
   local TERM_R=46  TERM_G=52  TERM_B=64      # #2E3440 terminal bg
-  local CWD_R=59   CWD_G=66   CWD_B=82       # #3B4252 Nord 1 (CWD cell)
-  local PN2_R=67   PN2_G=76   PN2_B=94       # #434C5E segment bg
   local SS1_R=216  SS1_G=222  SS1_B=233      # #D8DEE9 Snow Storm 1
   local FG_L_R=236 FG_L_G=239 FG_L_B=244    # #ECEFF4 light text
   local FG_D_R=46  FG_D_G=52  FG_D_B=64     # #2E3440 dark text
 
-  # PR status -> icon bg/fg (default: CWD bg, white icon)
-  local pr_bg_r=$CWD_R   pr_bg_g=$CWD_G   pr_bg_b=$CWD_B
+  # PR status -> icon bg/fg (default: Nord 1 bg, white icon)
+  local pr_bg_r=59   pr_bg_g=66   pr_bg_b=82
   local pr_fg_r=$FG_L_R  pr_fg_g=$FG_L_G  pr_fg_b=$FG_L_B
 
   case "$GIT_PR_STATUS" in
@@ -146,7 +148,7 @@ function _prompt_repo_dir() {
       ;;
   esac
 
-  # CWD: last 2 path components
+  # CWD: last 2 path components (fallback when no repo)
   local cwd=${PWD/#$HOME/\~}
   local dir_display
   if [[ "$cwd" == */*/* ]]; then
@@ -157,35 +159,36 @@ function _prompt_repo_dir() {
 
   local o=""
 
-  # -- CWD cell (always first) -- Nord 1 bg
-  o+="${_bg}${TERM_R};${TERM_G};${TERM_B}${_m}${_fg}${CWD_R};${CWD_G};${CWD_B}${_m}${_O}"
-  o+="${_bg}${CWD_R};${CWD_G};${CWD_B}${_m}${_fg}${FG_L_R};${FG_L_G};${FG_L_B}${_m} ${dir_display} "
+  # -- Identity cell (SS1 bg, dark text) -- opening wedge from terminal bg
+  o+="${_bg}${TERM_R};${TERM_G};${TERM_B}${_m}${_fg}${SS1_R};${SS1_G};${SS1_B}${_m}${_O}"
+  o+="${_bg}${SS1_R};${SS1_G};${SS1_B}${_m}${_fg}${FG_D_R};${FG_D_G};${FG_D_B}${_m}"
 
   if [[ -n "$GIT_REPO_NAME" ]]; then
-    # CWD -> repo name on SS1 (white bg, dark text)
-    o+="${_bg}${SS1_R};${SS1_G};${SS1_B}${_m}${_fg}${CWD_R};${CWD_G};${CWD_B}${_m}${_A}"
-    o+="${_fg}${FG_D_R};${FG_D_G};${FG_D_B}${_m} ${_ul}${_osc8_open}${GIT_REPO_HTTPS}${_osc8_mid}${GIT_REPO_NAME}${_osc8_close}${_noul} "
-    # Repo -> GH icon on PR status bg
+    # Repo name: linked, underlined
+    o+=" ${_ul}${_osc8_open}${GIT_REPO_HTTPS}${_osc8_mid}${GIT_REPO_NAME}${_osc8_close}${_noul} "
+    # Identity -> GH icon on PR status bg
     o+="${_bg}${pr_bg_r};${pr_bg_g};${pr_bg_b}${_m}${_fg}${SS1_R};${SS1_G};${SS1_B}${_m}${_A}"
     if [[ -n "$GIT_PR_URL" ]]; then
       o+="${_fg}${pr_fg_r};${pr_fg_g};${pr_fg_b}${_m} ${_osc8_open}${GIT_PR_URL}${_osc8_mid}${_GH}${_osc8_close} "
     else
       o+="${_fg}${pr_fg_r};${pr_fg_g};${pr_fg_b}${_m} ${_GH} "
     fi
-  elif [[ -n "$GIT_IS_REPO" ]]; then
-    # Git repo but no remote: CWD -> SEG_BG for git segment
-    o+="${_bg}${PN2_R};${PN2_G};${PN2_B}${_m}${_fg}${CWD_R};${CWD_G};${CWD_B}${_m}${_A}"
   else
-    # No git: close CWD cell
-    o+="${_rst}${_fg}${CWD_R};${CWD_G};${CWD_B}${_m}${_A}${_rst}"
+    # CWD path (no link)
+    o+=" ${dir_display} "
+    if [[ -z "$GIT_IS_REPO" ]]; then
+      # No git: close identity cell
+      o+="${_rst}${_fg}${SS1_R};${SS1_G};${SS1_B}${_m}${_A}${_rst}"
+    fi
   fi
 
   print -rn -- "$o"
 }
-# _prompt_git_seg — renders git branch + status pips
-# Reads: GIT_IS_REPO, GIT_BRANCH, STATUSLINE_WORKTREE,
-#        GIT_STASH_COUNT, GIT_CONFLICT_COUNT, GIT_UNTRACKED_COUNT,
-#        GIT_UNSTAGED_COUNT, GIT_STAGED_COUNT, GIT_AHEAD, GIT_BEHIND
+# _prompt_git_seg -- renders git branch + status pips
+# Reads: GIT_IS_REPO, GIT_BRANCH, GIT_REPO_NAME, GIT_PR_STATUS,
+#        STATUSLINE_WORKTREE, GIT_STASH_COUNT, GIT_CONFLICT_COUNT,
+#        GIT_UNTRACKED_COUNT, GIT_UNSTAGED_COUNT, GIT_STAGED_COUNT,
+#        GIT_AHEAD, GIT_BEHIND
 # Expects NOVA_* color vars from theme.sh (already sourced).
 function _prompt_git_seg() {
   [[ -z "$GIT_IS_REPO" ]] && return
@@ -199,7 +202,7 @@ function _prompt_git_seg() {
 
   # Branch pill opening
   if [[ -n "$GIT_REPO_NAME" ]]; then
-    # Arrow from GH icon cell (default: CWD bg) into branch
+    # Arrow from GH icon cell (PR status bg) into branch
     local _pr_r=59 _pr_g=66 _pr_b=82
     case "$GIT_PR_STATUS" in
       pass)    _pr_r=$NOVA_PR_PASS_R;    _pr_g=$NOVA_PR_PASS_G;    _pr_b=$NOVA_PR_PASS_B ;;
@@ -209,10 +212,9 @@ function _prompt_git_seg() {
     o+="${_bg}${_BR_R};${_BR_G};${_BR_B}${_m}"
     o+="${_fg}${_pr_r};${_pr_g};${_pr_b}${_m}${_A}"
   else
-    # Standard: space on SEG_BG, arrow into branch
-    o+="${_bg}${NOVA_SEG_BG_R};${NOVA_SEG_BG_G};${NOVA_SEG_BG_B}${_m} "
+    # Seamless from identity cell (both SS1) — invisible arrow
     o+="${_bg}${_BR_R};${_BR_G};${_BR_B}${_m}"
-    o+="${_fg}${NOVA_SEG_BG_R};${NOVA_SEG_BG_G};${NOVA_SEG_BG_B}${_m}${_A}"
+    o+="${_fg}${_BR_R};${_BR_G};${_BR_B}${_m}${_A}"
   fi
   o+="${_fg}${_BR_FG_R};${_BR_FG_G};${_BR_FG_B}${_m} ${GIT_BRANCH} "
   prev_r=$_BR_R; prev_g=$_BR_G; prev_b=$_BR_B

--- a/mise.toml
+++ b/mise.toml
@@ -2,3 +2,4 @@
 node = { version = "25.8.0", postinstall = "npm install -g typescript prettier eslint" }
 python = "3.13"
 deno = "2"
+rust = "1.94"


### PR DESCRIPTION
## Summary
- Add `JAVA_HOME`, `ANDROID_HOME`, and `platform-tools` to PATH for Android development
- Add Rust 1.94 to mise-managed language versions
- Consolidate prompt CWD and repo-name into a single identity cell (Snow Storm 1 bg), removing the separate Nord 1 CWD pill and simplifying powerline transitions

## Test plan
- [ ] Verify `echo $JAVA_HOME` and `echo $ANDROID_HOME` resolve correctly after sourcing `.zshrc`
- [ ] Verify `adb --version` works via the new PATH entry
- [ ] Run `mise install` and confirm Rust 1.94 installs
- [ ] Open a terminal in a git repo with a GitHub remote — confirm identity cell shows linked repo name + GH icon
- [ ] Open a terminal outside any git repo — confirm identity cell shows CWD path
- [ ] Verify powerline arrow transitions have no color artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)