### PR TITLE
chore(claude): drop worktree.baseRef override, enable verbose

### DIFF
--- a/dot-claude/settings.json
+++ b/dot-claude/settings.json
@@ -211,7 +211,6 @@
     ]
   },
   "worktree": {
-    "baseRef": "fresh",
     "symlinkDirectories": [
       "node_modules"
     ]
@@ -348,5 +347,6 @@
   "remoteControlAtStartup": true,
   "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "voiceEnabled": true
+  "voiceEnabled": true,
+  "verbose": true
 }


### PR DESCRIPTION
## Summary
- Remove `worktree.baseRef: "fresh"` override (revert to default)
- Enable `verbose: true`

## Test plan
- [ ] Verify worktree creation still works as expected
- [ ] Confirm verbose output appears in sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)