### PR TITLE
chore(claude): settings tweaks — worktree baseRef, agent view, notif flags

### DIFF
--- a/dot-claude/settings.json
+++ b/dot-claude/settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "cleanupPeriodDays": 14,
   "env": {
     "EDITOR": "nvim",
     "NODE_ENV": "development",
@@ -91,7 +92,10 @@
       "Bash(open *)"
     ],
     "defaultMode": "auto",
-    "additionalDirectories": ["/tmp/claude", "/private/tmp/claude"]
+    "additionalDirectories": [
+      "/tmp/claude",
+      "/private/tmp/claude"
+    ]
   },
   "skillOverrides": {
     "commit-commands:commit": "user-invocable-only",
@@ -208,7 +212,10 @@
     ]
   },
   "worktree": {
-    "symlinkDirectories": ["node_modules"]
+    "symlinkDirectories": [
+      "node_modules"
+    ],
+    "baseRef": "fresh"
   },
   "statusLine": {
     "type": "command",
@@ -254,6 +261,7 @@
       "autoUpdate": true
     }
   },
+  "forceLoginMethod": "claudeai",
   "outputStyle": "Concise",
   "sandbox": {
     "enabled": true,
@@ -305,7 +313,12 @@
         "~/Library/Caches/Homebrew",
         "~/Library/Logs/Homebrew"
       ],
-      "denyRead": ["~/.aws", "~/.gnupg", "~/.netrc", "~/.config/op"]
+      "denyRead": [
+        "~/.aws",
+        "~/.gnupg",
+        "~/.netrc",
+        "~/.config/op"
+      ]
     },
     "excludedCommands": [
       "git",
@@ -322,10 +335,7 @@
       "mise"
     ]
   },
-  "cleanupPeriodDays": 14,
   "feedbackSurveyRate": 0,
-  "forceLoginMethod": "claudeai",
-  "bypassPermissionsModeAccepted": true,
   "skipDangerousModePermissionPrompt": true,
   "editorMode": "vim",
   "verbose": true,
@@ -333,5 +343,7 @@
   "remoteControlAtStartup": true,
   "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "voiceEnabled": true
+  "voiceEnabled": true,
+  "bypassPermissionsModeAccepted": true,
+  "inputNeededNotifEnabled": true
 }


### PR DESCRIPTION
## Summary
- Set `worktree.baseRef` to `fresh` (default branch for new worktrees)
- Enable `inputNeededNotifEnabled` for input-needed notifications
- Add `forceLoginMethod: claudeai`
- Minor key reordering from /config write

## Test plan
- [ ] Verify Claude Code loads settings without schema errors
- [ ] Confirm new worktrees base off `fresh`
- [ ] Confirm input-needed notifications fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)