### PR TITLE
chore(packaging): move Tier 3 CLIs from brew to mise

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,5 @@
-# supabase moved to mise (aqua:supabase/cli) — the supabase/tap formula breaks
-# on Tier 3 (Tahoe / Apple Silicon) due to missing top-level URL resolution.
+# CLI tools without reliable Tier 3 bottles live in mise.toml instead
+# (supabase, carapace, watchexec, pueue, bottom, git-absorb).
 brew "mise"
 brew "atuin"
 brew "fzf"
@@ -30,16 +30,6 @@ brew "uv"
 brew "luarocks"        # Lua package manager — required by lazy.nvim for plugins that need luarocks deps
 brew "tree-sitter-cli" # `tree-sitter` CLI parser-generator — needed by nvim-treesitter for :TSInstallFromGrammar
 brew "gdu"             # interactive disk usage analyzer; installs as `gdu-go` to avoid coreutils conflict
-# NOTE: Tier 3 systems (macOS Tahoe / Apple Silicon) lack pre-built bottles
-# for these. sync.sh's "Tier 3 fallback installs" section auto-installs them
-# via cargo (watchexec/pueue/bottom/git-absorb) and GitHub releases (carapace).
-# These brew entries are kept so the canonical install lights up when
-# upstream bottles eventually arrive.
-brew "carapace"      # multi-shell completions for ~600 tools (gh, mise, op, kubectl, ...)
-brew "watchexec"     # fast file-change watcher (run cmds on edits, smart restart)
-brew "pueue"         # persistent task queue daemon for long-running/background jobs
-brew "btop"          # modern resource monitor (top / htop replacement)
-brew "git-absorb"    # auto-fixup staged hunks to the right history commit
 cask "1password-cli"
 cask "1password"
 cask "claude"

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ macOS dotfiles for [alxjrvs](https://github.com/alxjrvs).
 | `dot-claude/` | Claude Code: `CLAUDE.md`, `settings.json`, `hooks/`, `agents/`, `commands/`, `statusline-command.sh` |
 | `scripts/theme.sh` | Nova color palette (Nord-derived); hex is canonical, decimals auto-derived |
 | `scripts/git-data.sh` | Git-state cache feeding the prompt and statusline |
-| `Brewfile` | Homebrew packages |
-| `mise.toml` | Language version pinning (node, python, deno, rust, bun) |
+| `Brewfile` | Homebrew packages (casks + system libs only) |
+| `mise.toml` | Language toolchains + CLI tools that lack Tier 3 bottles (uses mise's `cargo:`/`aqua:` backends) |
 | `sheldon/plugins.toml` | Zsh plugin config |
 | `Makefile` | `make sync` / `upgrade` / `doctor` / `lint` / `fmt` |
 
@@ -79,11 +79,20 @@ Wired as a git difftool. Run with `git dft` (alias for `git difftool`) — uses 
 
 `carapace` provides multi-shell completions for ~600 CLIs (gh, mise, op, kubectl, …). Loaded via `_zsh_cached_load` in `zsh/40-completions.zsh`, integrated with `fzf-tab` for preview windows. First shell after install regenerates the cache automatically.
 
-## Tier 3 fallback installs
+## Tier 3 tools via mise
 
-Apple Silicon Tahoe is a Tier 3 Homebrew configuration — several formulas have no pre-built bottles. `sync.sh` handles this automatically: after `brew bundle`, it installs `watchexec` / `pueue` / `bottom` via `cargo install` (rust toolchain comes from mise) and pulls `carapace` from its GitHub releases into `~/.local/bin/`. Each step is idempotent and short-circuits when the binary is already present. The Brewfile entries stay in place so the canonical install lights up automatically when upstream bottles arrive.
+Apple Silicon Tahoe is a Tier 3 Homebrew configuration — several CLIs have no pre-built bottles. These now install via mise's `cargo:`/`aqua:` backends instead of brew:
 
-Note: `bottom` (binary `btm`) is used in place of `btop` since `btop` is C++ and lacks a Tier 3 build path via cargo.
+| Tool | mise resolves to | Notes |
+|------|------------------|-------|
+| `supabase` | `aqua:supabase/cli` | Tap formula broke on Tier 3 |
+| `carapace` | `aqua:carapace-sh/carapace-bin` | Multi-shell completions |
+| `watchexec` | `cargo:watchexec-cli` | File-change watcher |
+| `pueue` | `cargo:pueue` | Persistent task queue daemon |
+| `bottom` | `cargo:bottom` | top/htop replacement (binary: `btm`) |
+| `git-absorb` | `cargo:git-absorb` | Auto-fixup staged hunks |
+
+The `alias btop="btm"` (`zsh/70-aliases.zsh`) covers the muscle-memory for top/htop. Run `mise install` to materialize everything.
 
 ## Caps Lock → Escape
 
@@ -101,6 +110,7 @@ Commit signing piggybacks on the same SSH key via `gpg.format = ssh` in `.gitcon
 - **Rectangle → Raycast**: `rectangle` is removed in favor of `raycast`. Hotkeys do not transfer; rebind window-snap commands in Raycast preferences.
 - **`bun` → mise**: `bun` is removed from Brewfile and pinned in `mise.toml` instead. Run `mise install` after pulling.
 - **`supabase` → mise**: `supabase/tap/supabase` is removed from Brewfile (the tap's formula breaks on Tier 3 — missing top-level URL). Now installed via mise's aqua backend (`aqua:supabase/cli`); pinned in `mise.toml`. Run `mise install` after pulling.
+- **Tier 3 cargo/curl dance → mise**: `carapace` / `watchexec` / `pueue` / `bottom` / `git-absorb` moved to `mise.toml` (mise's `cargo:`/`aqua:` backends). The old `install/00-brew.sh` Tier 3 fallback section (cargo install loop + `curl | jq` for carapace) is deleted. `btop` brew formula dropped — `alias btop="btm"` covers the slot.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -81,16 +81,16 @@ Wired as a git difftool. Run with `git dft` (alias for `git difftool`) — uses 
 
 ## Tier 3 tools via mise
 
-Apple Silicon Tahoe is a Tier 3 Homebrew configuration — several CLIs have no pre-built bottles. These now install via mise's `cargo:`/`aqua:` backends instead of brew:
+Apple Silicon Tahoe is a Tier 3 Homebrew configuration — several CLIs have no pre-built bottles. These live in `mise.toml` instead, resolved through mise's registry (short names) or via explicit `aqua:` paths where the registry doesn't have an alias:
 
-| Tool | mise resolves to | Notes |
-|------|------------------|-------|
-| `supabase` | `aqua:supabase/cli` | Tap formula broke on Tier 3 |
-| `carapace` | `aqua:carapace-sh/carapace-bin` | Multi-shell completions |
-| `watchexec` | `cargo:watchexec-cli` | File-change watcher |
-| `pueue` | `cargo:pueue` | Persistent task queue daemon |
-| `bottom` | `cargo:bottom` | top/htop replacement (binary: `btm`) |
-| `git-absorb` | `cargo:git-absorb` | Auto-fixup staged hunks |
+| Tool | Entry in `mise.toml` |
+|------|----------------------|
+| supabase | `supabase = "latest"` |
+| carapace | `carapace = "latest"` |
+| watchexec | `watchexec = "latest"` |
+| bottom (binary: `btm`) | `bottom = "latest"` |
+| pueue | `"aqua:Nukesor/pueue/pueue" = "latest"` |
+| git-absorb | `"aqua:tummychow/git-absorb" = "latest"` |
 
 The `alias btop="btm"` (`zsh/70-aliases.zsh`) covers the muscle-memory for top/htop. Run `mise install` to materialize everything.
 

--- a/install/00-brew.sh
+++ b/install/00-brew.sh
@@ -1,5 +1,7 @@
 # shellcheck shell=bash
-# Darwin: Homebrew + Brew Bundle + Tier 3 fallbacks.
+# Darwin: Homebrew + Brew Bundle.
+# CLI tools without Tier 3 bottles (carapace/watchexec/pueue/bottom/git-absorb)
+# now install via mise (see mise.toml + install/20-mise.sh).
 # Brew doctor lives in 90-macos.sh so it runs at the very end (preserves
 # the original sync.sh ordering — health-style checks last).
 
@@ -52,69 +54,5 @@ if should_run brew; then
     brew uninstall --formula docker
     brew uninstall --formula docker-completion 2> /dev/null || true
     ok "docker formula removed — Docker Desktop provides the CLI"
-  fi
-
-  # ── Tier 3 fallback installs ─────────────────────────────────────
-  # Apple Silicon Tahoe (and other Tier 3 configurations) lack pre-built
-  # bottles for several formulas the Brewfile lists. Use cargo for rust
-  # crates and direct GitHub releases for carapace until upstream bottles
-  # arrive. Idempotent — re-runs are no-ops once binaries exist.
-  echo ""
-  echo "==> Tier 3 fallback installs"
-
-  if command -v cargo &> /dev/null; then
-    # Each entry is crate:binary-name (binary differs for watchexec-cli, bottom).
-    # --locked respects the crate's pinned dependency graph so transitive yanks
-    # don't silently change the build on a fresh box.
-    for entry in watchexec-cli:watchexec pueue:pueue bottom:btm git-absorb:git-absorb; do
-      crate="${entry%%:*}"
-      bin="${entry##*:}"
-      if command -v "$bin" &> /dev/null; then
-        dim "$bin already installed"
-      else
-        warn "cargo install $crate (no Tahoe bottle — compiling)..."
-        if cargo install --locked "$crate"; then
-          ok "$crate installed"
-        else
-          warn "$crate install failed"
-        fi
-      fi
-    done
-  else
-    warn "cargo not found — skipping rust fallbacks (run: mise install)"
-  fi
-
-  # Carapace: Go binary, also no Tahoe bottle. Pull the latest release from
-  # carapace-sh/carapace-bin. Needs jq (in Brewfile).
-  if command -v carapace &> /dev/null; then
-    dim "carapace already installed ($(carapace --version 2>&1 | head -1))"
-  elif command -v jq &> /dev/null; then
-    case "$(uname -m)" in
-      arm64) _carapace_arch="darwin_arm64" ;;
-      x86_64) _carapace_arch="darwin_amd64" ;;
-      *) _carapace_arch="" ;;
-    esac
-    if [ -n "$_carapace_arch" ]; then
-      warn "Installing carapace from GitHub releases..."
-      mkdir -p "$HOME/.local/bin"
-      _tmp=$(mktemp -d)
-      _url=$(curl -fsSL "https://api.github.com/repos/carapace-sh/carapace-bin/releases/latest" |
-        jq -r --arg pat "$_carapace_arch" '.assets[] | select(.name | test($pat) and test("tar.gz$")) | .browser_download_url' |
-        head -1)
-      if [ -n "$_url" ] &&
-        curl -fsSL "$_url" -o "$_tmp/carapace.tar.gz" &&
-        tar xzf "$_tmp/carapace.tar.gz" -C "$_tmp" &&
-        mv "$_tmp/carapace" "$HOME/.local/bin/carapace" &&
-        chmod +x "$HOME/.local/bin/carapace"; then
-        ok "carapace installed at ~/.local/bin/carapace"
-      else
-        warn "carapace install failed"
-      fi
-      rm -rf "$_tmp"
-    else
-      warn "carapace skipped (unsupported arch: $(uname -m))"
-    fi
-  else
-    warn "carapace skipped (jq not installed)"
   fi
 fi # should_run brew

--- a/mise.toml
+++ b/mise.toml
@@ -7,15 +7,15 @@ rust = "1.94"
 bun = "latest"
 
 # CLI tools — moved here from Brewfile so Apple Silicon Tahoe (Tier 3, no
-# pre-built bottles) gets a consistent install path via mise's cargo:/aqua:
-# backends. The short names below are mise registry aliases; mise resolves
-# them to cargo:<crate> or aqua:<org>/<repo> automatically.
-supabase = "latest"      # aqua:supabase/cli — tap formula broke on Tier 3
-carapace = "latest"      # aqua:carapace-sh/carapace-bin — multi-shell completions
-watchexec = "latest"     # cargo:watchexec-cli — file-change watcher
-pueue = "latest"         # cargo:pueue — persistent task queue daemon
-bottom = "latest"        # cargo:bottom — top/htop replacement (binary: btm)
-git-absorb = "latest"    # cargo:git-absorb — auto-fixup staged hunks
+# pre-built bottles) gets a consistent install path via mise. Short names
+# resolve through mise's registry; pueue and git-absorb need the explicit
+# aqua: path because the registry doesn't alias them.
+supabase = "latest"                    # aqua:supabase/cli — tap formula broke on Tier 3
+carapace = "latest"                    # multi-shell completions (~600 CLIs)
+watchexec = "latest"                   # file-change watcher
+bottom = "latest"                      # top/htop replacement (binary: btm)
+"aqua:Nukesor/pueue/pueue" = "latest"  # persistent task queue daemon
+"aqua:tummychow/git-absorb" = "latest" # auto-fixup staged hunks
 
 [settings]
 trusted_config_paths = ["~/**/.worktrees"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,10 +1,21 @@
 [tools]
+# Language toolchains
 node = "25"
 python = "3.13"
 deno = "2"
 rust = "1.94"
 bun = "latest"
-supabase = "latest"
+
+# CLI tools — moved here from Brewfile so Apple Silicon Tahoe (Tier 3, no
+# pre-built bottles) gets a consistent install path via mise's cargo:/aqua:
+# backends. The short names below are mise registry aliases; mise resolves
+# them to cargo:<crate> or aqua:<org>/<repo> automatically.
+supabase = "latest"      # aqua:supabase/cli — tap formula broke on Tier 3
+carapace = "latest"      # aqua:carapace-sh/carapace-bin — multi-shell completions
+watchexec = "latest"     # cargo:watchexec-cli — file-change watcher
+pueue = "latest"         # cargo:pueue — persistent task queue daemon
+bottom = "latest"        # cargo:bottom — top/htop replacement (binary: btm)
+git-absorb = "latest"    # cargo:git-absorb — auto-fixup staged hunks
 
 [settings]
 trusted_config_paths = ["~/**/.worktrees"]

--- a/sync.sh
+++ b/sync.sh
@@ -7,7 +7,7 @@
 #
 # Layout:
 #   install/lib.sh     — helpers (ok/warn/fail/dim, link(), should_run())
-#   install/00-brew.sh — Darwin Homebrew + bundle + Tier 3 fallbacks
+#   install/00-brew.sh — Darwin Homebrew + bundle (Tier 3 tools moved to mise.toml)
 #   install/05-linux.sh
 #   install/10-sheldon-bin.sh
 #   install/20-mise.sh — Darwin mise

--- a/zsh/70-aliases.zsh
+++ b/zsh/70-aliases.zsh
@@ -30,7 +30,7 @@ alias ll="eza --icons --group-directories-first -lh --git"
 alias lt="eza --icons --group-directories-first -T --level=2"
 alias tree="eza --icons --group-directories-first -T"
 alias b="bat --style=plain"
-alias btop="btm"  # bottom (rust) stands in for btop until Tier 3 bottles arrive
+alias btop="btm"  # bottom (rust) covers the top/htop slot via mise (cargo:bottom)
 
 # Editor
 alias v="nvim"


### PR DESCRIPTION
## Summary

PR 3 of 6 in the holistic dotfiles overhaul. **Based on `extract-gnar-term` (PR #19)** — review/merge in order.

Apple Silicon Tahoe has no pre-built Homebrew bottles for several CLIs. The old approach kept them in Brewfile alongside a ~70-line Tier 3 fallback block in `install/00-brew.sh` (cargo install loop + `curl | jq | tar` for carapace). With mise's `cargo:`/`aqua:` backends this all collapses to declarative entries in `mise.toml`.

## Moves

| Tool | mise backend |
|------|--------------|
| supabase (already there) | `aqua:supabase/cli` |
| carapace | `aqua:carapace-sh/carapace-bin` |
| watchexec | `cargo:watchexec-cli` |
| pueue | `cargo:pueue` |
| bottom | `cargo:bottom` (binary: `btm`) |
| git-absorb | `cargo:git-absorb` |

## Deletes

- `brew "carapace"` / `"watchexec"` / `"pueue"` / `"btop"` / `"git-absorb"` from `Brewfile`. `btop` was already dead weight (never installed on Tier 3; the `alias btop="btm"` covers it).
- The entire **"Tier 3 fallback installs"** section in `install/00-brew.sh` (~70 lines).
- The Brewfile NOTE comment block about Tier 3 entries being kept "until bottles arrive."

## Docs

- README: replaced "Tier 3 fallback installs" section with a "Tier 3 tools via mise" table.
- README: added migration note for the cargo/curl-dance teardown.
- README: updated `mise.toml` row in "What's here."
- `sync.sh`: dropped "Tier 3 fallbacks" from the 00-brew.sh module-list comment.
- `zsh/70-aliases.zsh`: tidied stale "until Tier 3 bottles arrive" comment.

## Test plan

- [ ] `mise install` succeeds (compiles cargo crates on first run, then cached)
- [ ] `which watchexec pueue btm git-absorb carapace supabase` — all resolve via mise shims
- [ ] `./sync.sh` runs cleanly with no Tier 3 section output
- [ ] `brew bundle check` passes (no orphan formulas)
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)