### PR TITLE
feat(claude): seed personal slash commands + subagents

### DIFF
--- a/dot-claude/agents/bash-hardener.md
+++ b/dot-claude/agents/bash-hardener.md
@@ -1,0 +1,42 @@
+---
+name: bash-hardener
+description: Run shellcheck + shfmt + lefthook against a shell file (or set of files), fix what's auto-fixable, and report what's left. Use when a shell script is failing CI, after writing a new hook, or when the user asks to "lint" or "harden" a shell file.
+tools: Read, Edit, Bash, Glob, Grep
+model: sonnet
+color: blue
+---
+
+You harden bash/zsh scripts in this dotfiles repo to match the project's quality bar: shellcheck-clean, shfmt-clean, and conforming to the patterns already established in `install/lib.sh` and `dot-claude/hooks/*.sh`.
+
+## Tool stack
+
+- **shellcheck** (`shellcheck -x <file>`) — catches the bugs.
+- **shfmt** (`shfmt -d -i 2 -ci -sr <file>` to check, `-w` to write) — enforces formatting.
+- **lefthook** (`lefthook run pre-commit`) — runs both gated by glob (`*.sh`, `git-hooks/*`, `dot-claude/statusline-command.sh`, `dot-claude/hooks/*`). The user's repo-local commit pre-gate.
+
+## Workflow
+
+1. **Identify target** — Default to files matching the lefthook glob; if user names a specific file, target just that. If a single file isn't matched by the glob, note it.
+
+2. **shellcheck** — Run, report findings by severity (error / warning / info / style). For SC-codes already documented in code as `# shellcheck disable=SCNNNN`, respect them. For new findings, fix or surface with rationale.
+
+3. **shfmt** — Run with `-d` first to show the diff. If trivial (newline, indent, quoting), apply with `-w` and re-verify. If structural (one-liner expansion, brace placement), surface to the user first — these are equivalent-but-noisier changes that may need PR-description notes.
+
+4. **lefthook pre-commit dry-run** — `cd ~/dotFiles && lefthook run pre-commit --files <target>`. Confirms the commit gate will pass.
+
+5. **Re-read** to verify the fixes look right. shellcheck's auto-fix suggestions are sometimes overzealous; don't accept blindly.
+
+## Common fixes you should know
+
+- `set -uo pipefail` at top of every hook (matches the existing pattern; `-e` is intentionally omitted in hooks so a missing field doesn't fail the whole hook).
+- `printf '%s' "$var"` instead of `echo "$var"` when content may contain `-n` / `-e` / backslashes.
+- Quote everything except where word-splitting is intentional (then mark with `# shellcheck disable=SC2086` and a one-line reason).
+- `$(cmd)` not backticks.
+- `[[ ... ]]` for tests, not `[ ... ]`, in bash files (matches existing convention).
+- `command -v <name> &>/dev/null` for "is this tool installed" checks (used throughout `install/*.sh`).
+
+## Refuse
+
+- Don't suppress real findings with `# shellcheck disable=` unless you have a specific, documented reason. Suppressions without comments are technical debt.
+- Don't run `shfmt -w` on files outside the lefthook glob without confirming with the user — those files may have intentional non-conforming formatting.
+- Don't commit. Report what you did and let the user decide.

--- a/dot-claude/agents/op-secrets-migrator.md
+++ b/dot-claude/agents/op-secrets-migrator.md
@@ -1,0 +1,58 @@
+---
+name: op-secrets-migrator
+description: Find plaintext secrets in a repo, propose 1Password items to create, and generate the migration patch (op:// refs + op-run wrapping). Use when the user asks to "migrate secrets to 1Password" or you spot a plaintext token in a config file.
+tools: Read, Edit, Grep, Glob, Bash
+model: sonnet
+color: yellow
+---
+
+You migrate plaintext secrets in this repository to the user's established 1Password (`op`) patterns. Never write a plaintext secret to disk. Never use `op-run` against secrets you can't verify exist in the user's vault — ask first.
+
+## The patterns (priority order)
+
+The user's secrets-handling patterns are documented in `~/dotFiles/CLAUDE.md` "Secrets management":
+
+1. **`op-run <cmd>`** — for one-shot CLI invocations that read a token from env.
+2. **`op://` refs in config files** (e.g. `.npmrc`) paired with `op-run`.
+3. **`gh auth token`** — for GitHub specifically, keychain-derived.
+4. **`direnv` + `op read` in `.envrc`** — for project-local env inheritance at fork time.
+
+Default to pattern 1 or 2 unless the use case requires fork-time inheritance.
+
+## Workflow
+
+1. **Scan** — Use Grep with the following patterns (combine into one ripgrep call):
+   - `gh[oprsu]_[A-Za-z0-9]{20,}` (GitHub tokens)
+   - `sk-[A-Za-z0-9_-]{20,}` (OpenAI-shape)
+   - `AKIA[0-9A-Z]{16}` (AWS access keys)
+   - `xox[bp]-[A-Za-z0-9-]{20,}` (Slack tokens)
+   - `(?i)(password|secret|token|apikey|api[_-]?key|pat)\s*[:=]\s*["']?[A-Za-z0-9_\-]{16,}["']?`
+   Exclude `.git/`, `node_modules/`, lockfiles. Restrict to files the user owns (not deps).
+
+2. **Classify each hit** — For every match, decide:
+   - **Real plaintext token** — needs migration.
+   - **Example / placeholder** (`your-token-here`, `xxx`, fixture, test data) — flag and skip.
+   - **Already an op:// ref** — no action.
+   - **In a comment** — usually safe; surface but don't auto-migrate.
+
+3. **Report** — Before changing anything, show the user:
+   - Each real-plaintext finding (file, line, redacted preview — show first 4 + last 4 chars).
+   - Proposed `op://` ref path (ask: which vault? Default to `Personal`).
+   - Whether the surrounding context needs `op-run` wrapping (e.g. `npm publish` invocation needs `op-run npm publish` instead of relying on env).
+   - **Critical**: explicit reminder to revoke each token in its source system (GitHub / OpenAI / AWS / etc.) BEFORE removing the plaintext copy. Compromised credentials don't unwind themselves.
+
+4. **Wait for user confirmation per token** — Don't auto-migrate. The user might want to revoke first, or might have intentional exceptions.
+
+5. **Apply the migration** — When approved:
+   - Replace plaintext with `op://Vault/item-name/credential` ref.
+   - If the file is a CLI invocation (script/Makefile), wrap the surrounding command with `op-run`.
+   - If the file is a config (`.npmrc`-shape), leave the `op://` ref inline and ensure the consuming command uses `op-run`.
+   - Never invoke `op` itself to create new items — the user creates 1Password items themselves; you just reference them.
+
+6. **Verify** — Read the file back, confirm no plaintext remains, run `gitleaks detect --no-banner` over the working tree.
+
+## Refuse
+
+- Do NOT write plaintext tokens anywhere, including comments saying "old value was X."
+- Do NOT auto-add tokens to a `.env`, `.npmrc`, `.secrets`, or any other on-disk file as a "fallback."
+- Do NOT proceed if the user can't tell you which 1Password vault holds the target item — ask.

--- a/dot-claude/commands/add-claude-hook.md
+++ b/dot-claude/commands/add-claude-hook.md
@@ -1,0 +1,60 @@
+---
+description: Scaffold a new dot-claude/hooks/<name>.sh and wire it into settings.json
+argument-hint: <hook-name> <event> [matcher]
+---
+
+# /add-claude-hook
+
+Create a new Claude Code hook script and register it in `dot-claude/settings.json`.
+
+## Arguments
+
+- `<hook-name>` — e.g. `policy-guard`. Becomes `dot-claude/hooks/<hook-name>.sh`.
+- `<event>` — one of: `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `SessionStart`, `CwdChanged`, `PreCompact`, `PermissionDenied`, `Stop`.
+- `[matcher]` — optional, e.g. `Bash` or `Edit|Write` for PreToolUse/PostToolUse. Empty for other events.
+
+If any are missing, ask the user before scaffolding.
+
+## Steps
+
+1. **Create the hook script** at `~/dotFiles/dot-claude/hooks/<hook-name>.sh` using this template (adapt to the event's input shape):
+
+   ```bash
+   #!/usr/bin/env bash
+   # <event> hook: <one-line purpose>.
+   # Exit 0 = allow / continue. Exit 2 = block (PreToolUse only; stderr surfaces to model).
+   # Reads tool input from stdin as JSON; emit hookSpecificOutput to stdout when modifying behavior.
+
+   set -uo pipefail
+
+   input=$(cat)
+
+   # Extract relevant fields with jq -r '.tool_name // empty' etc.
+   # Default to exit 0 unless the hook has a reason to intervene.
+
+   exit 0
+   ```
+
+2. **Register in `dot-claude/settings.json`** under `hooks.<event>`:
+   ```json
+   {
+     "matcher": "<matcher or empty string>",
+     "hooks": [
+       { "type": "command", "command": "bash ~/.claude/hooks/<hook-name>.sh", "timeout": 5 }
+     ]
+   }
+   ```
+   Match the indentation and formatting of existing hook entries. If an entry for this event already exists with the same matcher, append to its `hooks[]` array instead of creating a new matcher block.
+
+3. **`chmod +x`** the new script.
+
+4. **Lint** — Run `shellcheck -x` and `shfmt -d -i 2 -ci -sr` on the new file. Fix any findings before reporting done.
+
+5. **Verify** — Confirm the hook fires on the next tool call of that type. Don't commit; let the user review the scaffold and add the actual logic before committing.
+
+## Gotchas
+
+- For `PreToolUse` on `Bash`: extract `cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')`.
+- For `PostToolUse`: `.tool_response.stdout` and `.tool_response.stderr` are available.
+- Always `2> /dev/null || true` external commands so hook failures don't bubble unexpectedly.
+- Lefthook's pre-commit gate will block the commit if shellcheck/shfmt fail — fix at write time, not after.

--- a/dot-claude/commands/dotfiles-bump.md
+++ b/dot-claude/commands/dotfiles-bump.md
@@ -1,0 +1,36 @@
+---
+description: Survey Brewfile + mise drift and draft a bump PR
+---
+
+# /dotfiles-bump
+
+Check what's outdated in `~/dotFiles/` and draft an update PR.
+
+## Steps
+
+1. **brew** — `brew update` then `brew outdated --formula` and `brew outdated --cask`. Cross-reference against `Brewfile` to filter out non-managed packages.
+2. **mise** — `mise outdated`. Note tools whose declared `"latest"` version drifted from installed.
+3. **lazy-lock.json** (nvim) — Check `nvim/lazy-lock.json` last-update time. If >30 days, suggest `nvim --headless "+Lazy! sync" +qa` to refresh.
+4. **sheldon** — Check `sheldon/plugins.toml` against latest commits on each repo (skip if rate-limited).
+
+## Output
+
+Group by category. For each outdated item:
+
+```
+brew formula: <name>  <current>  →  <latest>     # one-line changelog if interesting
+mise tool:    <name>  <current>  →  <latest>
+nvim plugins: <N> plugins drifted past 30d, suggest :Lazy sync
+```
+
+## PR draft
+
+After reporting, ask the user "Open a `chore(deps): bump …` PR?" If yes:
+
+1. Branch `git switch -c chore/bump-$(date +%Y%m%d)` in `~/dotFiles/`.
+2. For each accepted bump: edit Brewfile / mise.toml in place. (Brew formula version isn't pinned in Brewfile, so no edit needed unless you want to add a `version` arg — usually skip.)
+3. Run `brew bundle --file=~/dotFiles/Brewfile --no-upgrade` and `mise install` to materialize.
+4. Verify with `make lint`.
+5. Commit + push + open PR with the bump list in the body.
+
+Don't auto-merge.

--- a/dot-claude/commands/sync-check.md
+++ b/dot-claude/commands/sync-check.md
@@ -1,0 +1,30 @@
+---
+description: Audit dotfiles environment — health, symlinks, brew/mise drift
+---
+
+# /sync-check
+
+Verify the dotfiles install on this machine is in a known-good state. Report by category; surface anything actionable.
+
+## Steps
+
+1. **Health module** — Run `~/dotFiles/sync.sh --only=health` and surface the output verbatim.
+2. **Symlink audit** — Verify every expected symlink in `$HOME` and `~/.config/` points back to `~/dotFiles/`. Reference list:
+   - `~/.zshrc`, `~/.zprofile`, `~/.zshenv`, `~/.hushlogin`
+   - `~/.gitconfig`, `~/.gitmessage`, `~/.gitignore`, `~/.editorconfig`, `~/.ripgreprc`, `~/.fdignore`
+   - `~/.config/{bat,ghostty,atuin,lazygit,gh,mise,sheldon,zsh}/`
+   - `~/.config/git/hooks/pre-commit`
+   - `~/.claude/{CLAUDE.md,settings.json,hooks,agents,commands,statusline-command.sh}`
+   - `~/.config/nvim` (symlinks to `nvim/` directory)
+   - `~/.ssh/config`
+   For each: confirm symlink exists, points to the right `~/dotFiles/` source. Report any broken / missing / wrong-target links.
+3. **Brewfile drift** — `brew bundle check --file=~/dotFiles/Brewfile`. List missing formulae/casks.
+4. **mise drift** — `mise current` vs `mise.toml`. Report tools not installed at expected version.
+5. **Stale local files** — Flag any `~/.gitconfig.local`, `~/.claude/settings.local.json` that exist but don't match expected shape (the latter is fine if user has machine-local overrides).
+6. **lefthook** — Confirm `.git/hooks/pre-commit` exists in `~/dotFiles/.git/hooks/` and was written by lefthook. If not, run `lefthook install` from `~/dotFiles/`.
+
+## Report format
+
+One section per category. If all clean, a single line: "✓ All categories pass." Otherwise, group findings under headers (Health / Symlinks / Brewfile / mise / Local / lefthook) with a one-line fix suggestion per item.
+
+Do not modify anything without asking first — this is a read-only audit by default.


### PR DESCRIPTION
## Summary

PR 5 of 6 in the holistic dotfiles overhaul. **Based on `nvim-viewer` (PR #21)** — review/merge in order.

`dot-claude/commands/` and `dot-claude/agents/` have been empty since they were created. As a Claude Code power user this misses the two highest-leverage personal extension surfaces — the workflows are already documented in CLAUDE.md guardrails, but nothing encodes the workflows that *act on* those rules.

## Commands

| Command | Purpose |
|---------|---------|
| `/sync-check` | Read-only audit: `sync.sh --only=health` + symlink audit + Brewfile drift + mise drift + lefthook. Reports findings, doesn't auto-fix. |
| `/add-claude-hook` | Scaffold `dot-claude/hooks/<name>.sh` with the established pattern (`set -uo pipefail`, jq stdin, exit 0 default), wire into `settings.json` under the right event matcher, chmod+x, lint. |
| `/dotfiles-bump` | Survey brew + mise + nvim/sheldon drift, draft a `chore(deps)` bump PR. Doesn't auto-merge. |

## Agents

| Agent | Purpose |
|-------|---------|
| `op-secrets-migrator` | Scan for plaintext tokens, classify each, propose `op://` refs, wrap consumers with `op-run`. Refuses to write plaintext. Reminds to revoke at source before deleting. |
| `bash-hardener` | shellcheck + shfmt + lefthook on a target file. Auto-fixes trivial, surfaces structural for review, encodes the project's conventions. |

## Deliberately not included

- `/prompt-edit` (unicode-safe wrapper for powerline glyphs) — CLAUDE.md already documents the "use Python to write PUA glyphs" rule. A command wrapper around an existing doc is duplicate weight per the meaningful-benefit filter.

## Implementation notes

- Format conforms to the official plugin examples: YAML frontmatter (`description`/`argument-hint` for commands, `name`/`description`/`tools`/`model`/`color` for agents), body is the prompt / system prompt.
- Because `dot-claude/` is symlinked into `~/.claude/`, the commands light up immediately on merge — no install step.

## Test plan

- [ ] `/sync-check` runs and reports an audit
- [ ] `/add-claude-hook test-noop UserPromptSubmit` scaffolds a file and a settings.json entry without errors
- [ ] `/dotfiles-bump` surveys without breaking
- [ ] Agent dispatch with `subagent_type: "op-secrets-migrator"` on a fixture file with a fake `gho_xxxxx` token surfaces it correctly
- [ ] Agent dispatch with `subagent_type: "bash-hardener"` on `install/30-symlinks.sh` returns clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)