### PR TITLE
fix(sync): correct ghostty module fn names so sync runs it

### DIFF
--- a/install/50-ghostty.sh
+++ b/install/50-ghostty.sh
@@ -15,9 +15,9 @@ if [[ -z "${__DOT_SYNC_SOURCED:-}" ]]; then
   }
 fi
 
-_ghostty_shim_tags() { printf 'ghostty\n'; }
+_ghostty_tags() { printf 'ghostty\n'; }
 
-_ghostty_shim_run() {
+_ghostty_run() {
   if [[ "$(os_kind)" != "darwin" ]]; then
     return 0
   fi


### PR DESCRIPTION
Follow-up to #25. The `dot sync` run on a real machine surfaced this: `install/50-ghostty.sh` defined `_ghostty_shim_tags`/`_ghostty_shim_run`, but `sync` derives the tag/run function names from the module filename (`50-ghostty.sh` → `_ghostty_tags`/`_ghostty_run`), so the step was silently **skipped** (`no _ghostty_tags() function — skipping`).

Rename the two functions to match the convention. Verified: `dot sync --only=ghostty` now runs the shim step instead of skipping it. All other modules already match the convention (audited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)