### PR TITLE
feat: agent-based git signing + sandbox-escape cleanup

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -23,7 +23,10 @@
 [user]
 	name = alxjrvs
 	email = alxjrvs@gmail.com
-	signingkey = ~/.ssh/id_ed25519.pub
+	# Literal pubkey (not a file path) → git signs via ssh-agent (-U), so the
+	# private key file is never read at commit time. The agent is loaded at
+	# login by .zprofile; the sandbox only needs the agent socket allowed.
+	signingkey = key::ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOPKPdTHi3qsWUMivyLIXbsQ22P8F1/gMGPHuLgFUoDP jarvis@Alexs-MacBook-Air.local
 [credential]
 	helper = osxkeychain
 [core]

--- a/.zprofile
+++ b/.zprofile
@@ -5,3 +5,17 @@ export XDG_CONFIG_HOME="$HOME/.config"
 
 # PATH (login shell only — prevents duplication in subshells)
 export PATH="$HOME/.local/bin:$PATH"
+
+# GitHub token from the gh CLI keychain (CLAUDE.md secrets pattern 3).
+# Login shell only: forks `gh auth token` once per login instead of on every
+# interactive subshell, and still inherits at fork time into child processes
+# (e.g. the github MCP server). The :- guard avoids re-forking when already set.
+export GITHUB_PERSONAL_ACCESS_TOKEN="${GITHUB_PERSONAL_ACCESS_TOKEN:-$(gh auth token 2> /dev/null)}"
+
+# Git signing key → Apple ssh-agent (silent signing, no per-commit prompts).
+# .gitconfig user.signingkey is the literal pubkey, so git signs via the
+# agent (-U) and never reads the private key file — the Claude sandbox only
+# allows the agent socket, not the key. Auth keys still live in 1Password
+# (ssh/config IdentityAgent); this on-disk key exists for signing only.
+# Login shell only; skips the fork when the agent already has identities.
+ssh-add -l > /dev/null 2>&1 || ssh-add -q ~/.ssh/id_ed25519 2> /dev/null

--- a/dot-claude/settings.json
+++ b/dot-claude/settings.json
@@ -20,6 +20,7 @@
       "Skill(superpowers:*)",
       "Skill(implement:*)",
       "Bash(node *)",
+      "Bash(npm *)",
       "Bash(bun *)",
       "Bash(bunx *)",
       "Bash(mise *)"
@@ -235,11 +236,15 @@
         "bun.sh",
         "nodejs.org",
         "typescriptlang.org",
-        "stackoverflow.com"
+        "stackoverflow.com",
+        "localhost",
+        "127.0.0.1"
       ],
       "allowUnixSockets": [
         "/tmp/tsx-*/*.pipe",
-        "/private/tmp/tsx-*/*.pipe"
+        "/private/tmp/tsx-*/*.pipe",
+        "/var/run/com.apple.launchd.*/Listeners",
+        "/private/var/run/com.apple.launchd.*/Listeners"
       ],
       "allowLocalBinding": true,
       "allowMachLookup": [
@@ -280,6 +285,9 @@
         "~/Library/Caches/Homebrew",
         "~/Library/Logs/Homebrew",
         "~/Library/Caches/mise",
+        "~/Library/Caches/ms-playwright",
+        "~/Code",
+        "~/**/node_modules",
         "~/**/.git/HEAD",
         "~/**/.git/index",
         "~/**/.git/index.lock",
@@ -309,6 +317,7 @@
       "brew",
       "open",
       "node",
+      "npm",
       "bun",
       "bunx",
       "mise",


### PR DESCRIPTION
## Why

A scan of all session transcripts (2026-05-17 → 2026-06-05) found **2,914 manual sandbox escapes across 171 sessions**. ~85% fall into a handful of recurring buckets. This PR clears them — without making any secret readable inside the sandbox.

## Git signing: Apple ssh-agent (the big one)

`excludedCommands` only matches a *leading* `git`, so any compound command (`cd x && git commit`) stays sandboxed and previously couldn't read the SSH signing key → constant escape prompts.

Fix per upstream best practice ([git ssh signing via agent](https://dev.to/ccoveille/git-the-complete-guide-to-sign-your-commits-with-an-ssh-key-35bg), [1Password signing docs](https://developer.1password.com/docs/ssh/git-commit-signing/)):

- `user.signingkey` becomes the **literal pubkey** (`key::ssh-ed25519 …`) → git signs via `ssh-keygen -Y sign -U`, i.e. through the **agent socket**, never reading the private key file
- `~/.ssh/id_ed25519` stays **denyRead** in the sandbox; only the launchd agent socket (`/var/run/com.apple.launchd.*/Listeners`) is allowed
- `.zprofile` loads the key into the Apple agent at login (silent — no per-commit prompts, unlike op-ssh-sign; 1Password keeps owning *auth* keys via ssh/config `IdentityAgent`)
- Same public key → GitHub + `allowed_signers` unchanged

Verified: `git log --show-signature` + `ssh-keygen -Y verify` → *Good signature*, signed by agent with zero prompts.

## Other buckets

| Escapes | Cause | Fix |
|---:|---|---|
| 562 | npm runs | `npm` in `excludedCommands` + `Bash(npm *)` allow (node/bun/bunx parity) |
| ~1,280 | cross-project `cd`+git churn, node_modules/dist writes | allowWrite `~/Code`, `~/**/node_modules` |
| 148 | Playwright browser downloads | allowWrite `~/Library/Caches/ms-playwright` |
| 68 | localhost health-check curls | `localhost`/`127.0.0.1` in allowedDomains |

(mise cache + tsx IPC pipe already landed on main: `ee92b4d`, `eff1f9c`.)

## Notes

- Broadest line: allowWrite `~/Code` — sandboxed commands can write any repo, matching what Edit/Write already allow with permission rules as the gate. Drop that line if it feels too wide; per-project `.claude/settings.local.json` is the narrow alternative.
- New sessions pick up the sandbox changes; running sessions keep their frozen profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)