### PR TITLE
Apply audit remediation roadmap (N1–N5, X1–X8, L1–L10)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,45 @@
+name: lint
+
+# Mirrors the local lefthook pre-commit gate (shellcheck + shfmt + gitleaks +
+# settings.json validity) plus the bats unit tests, on every push to main and
+# every PR. Lint only — never runs `dot sync` or mutates anything.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Set mise up (PATH + shims) but skip the full `mise install` — we only
+      # need the five lint tools, not the whole toolchain (node, bun, neovim…).
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+      - name: Install lint tools
+        run: mise install shellcheck shfmt gitleaks jq bats
+
+      # Same file set as lefthook.yml's shell globs, resolved via git.
+      - name: shellcheck
+        run: shellcheck -x $(git ls-files '*.sh' dot sync doctor watchtower bootstrap.sh 'git-template/hooks/*')
+      - name: shfmt
+        run: shfmt -d -i 2 -ci -sr $(git ls-files '*.sh' dot sync doctor watchtower bootstrap.sh 'git-template/hooks/*')
+
+      # Scan the current tree (not full history) — mirrors the intent of the
+      # pre-commit secret gate without risking flaky failures on old history.
+      # Deep-history scanning is available on demand via `dot doctor --full`.
+      - name: gitleaks
+        run: gitleaks detect --no-git --redact --no-banner
+
+      - name: settings.json validity
+        run: jq -e . dot-claude/settings.json > /dev/null
+
+      - name: bats unit tests
+        run: bats test/

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ yarn-error.log*
 # Transient/generated
 Brewfile.lock.json
 
+# Generated audit reports (gnar audit plugin) — regenerate on demand, not tracked.
+audit/
+
 # Machine-specific overrides
 dot-claude/settings.local.json
 **/.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,13 @@ dot sync                # Idempotent install/resync. Fast on no-op.
 dot sync --upgrade      # Same + brew update/upgrade/cleanup + mise upgrade.
 dot sync --only=brew,mise   # Only the listed section tags.
 dot update              # Bump everything (equivalent to sync --upgrade).
-dot doctor              # Read-only health check; exits non-zero on failures.
+dot sync --dry-run      # Mutate nothing; print what each module WOULD do.
+dot doctor              # Read-only health check. Exit: 0 clean, 1 failures, 2 warnings only.
 dot doctor --fix        # Same + repair symlinks: reap orphans, relink missing/incorrect.
+dot doctor --full       # Same + a full-history gitleaks scan (slow, on-demand).
 dot watchtower          # Local 1Password security audit via the op CLI (foreground only).
 lefthook run pre-commit # shellcheck + shfmt -i 2 -ci -sr over staged shell files.
+mise x -- bats test/    # Run the lib/common.sh unit tests.
 ```
 
 Fresh machine: `git clone … ~/dotFiles && ~/dotFiles/bootstrap.sh` (execs `dot sync`).
@@ -101,9 +104,15 @@ Each entry is symlinked individually into `~/.claude/` by `dot sync` (claude tag
 
 Don't add `agents/`, `commands/`, or `hooks/` directories without asking — `dot-claude/` stays at these two symlinked files plus `REFERENCE.md`.
 
-### Linting
+### Linting & tests
 
-`lefthook.yml` runs a pre-commit gate over staged shell files: `shellcheck` + `shfmt -i 2 -ci -sr` + `gitleaks protect` + a `settings.json` validity check. `dot sync` (lefthook tag) installs the hooks. No test suite and no CI — this is a personal repo; the lint gate is the only automation.
+Three lightweight automation layers:
+
+- **pre-commit** (`lefthook.yml`, installed by `dot sync` lefthook tag): `shellcheck` + `shfmt -i 2 -ci -sr` + `gitleaks protect` + a `settings.json` validity check over staged shell files.
+- **commit-msg** (`lefthook.yml`): rejects throwaway subjects (bare `WIP`/`wip` or a single character) so they don't enter permanent history. Commit convention is `scope: summary` or `type(scope): summary` (e.g. `feat(mcp): …`, `docs+chore: …`). Bypass once with `git commit --no-verify`.
+- **CI** (`.github/workflows/lint.yml`): mirrors the pre-commit gate (shellcheck/shfmt/gitleaks/settings) and runs the `bats` unit tests on push to `main` and on PRs. Lint only — never runs `dot sync` or mutates anything.
+
+Tests live in `test/` (`bats`): `test/common.bats` covers the `lib/common.sh` helpers (`link`, `os_kind`, `resolve_dotfiles_dir`). Run locally with `mise x -- bats test/`. The surface is deliberately small — `lib/common.sh` has the highest fan-in (sourced by `sync`, `doctor`, `watchtower`), so that's where a unit test earns its weight; the installer modules stay verified by `dot sync --dry-run` rather than a heavier harness.
 
 ## Packaging policy: Lean A (brew = casks, mise = dev CLIs)
 
@@ -198,4 +207,4 @@ Pause and confirm with the user before doing any of these:
 - **Sheldon plugin order matters**: `fast-syntax-highlighting` must be last in `sheldon/plugins.toml`. It wraps every existing ZLE widget at load time, so anything that registers a widget must run before sheldon's `eval` line in `zsh/30-plugins.zsh`.
 - **`dot` self-locates**: `dot` resolves `DOTFILES_DIR` from its own resolved symlink target, so the repo is relocatable. To move it: `mv` the repo, then run `DOTFILES_DIR=<new> <new>/dot sync --force` once to relink (or just re-run `bootstrap.sh`).
 - **`gh` auth is keychain-backed**: the OAuth token lives in the macOS login keychain (gh secure storage); `~/.config/gh/hosts.yml` carries only non-secret host metadata. If a future `gh auth login` ever uses `--insecure-storage` it will dump the token plaintext into `hosts.yml` — don't; re-login with default (secure) storage. `gh auth status` should show `(keyring)`.
-- **`dot sync --only=<tag>` requires the tag to exist**: a module's declared tag and the `--only=` value must agree, or `--only=foo` silently runs nothing.
+- **`dot sync --only=<tag>` requires the tag to exist**: a module's declared tag and the `--only=` value must agree. A tag no module declares fails loudly (`==> ✗ --only=foo matched no module`, exit 1) — it does not silently run nothing.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-2026 alxjrvs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ git clone https://github.com/alxjrvs/dotFiles ~/dotFiles
 
 `bootstrap.sh` is a few lines of shell: it `exec`s `~/dotFiles/dot sync`, which installs everything and symlinks `dot` onto your `PATH` at `~/.local/bin/dot`. After that everything is `dot <subcommand>`.
 
+_Last tested on macOS 26 (Tahoe) / Darwin 25, June 2026._ To preview without touching the machine first: `dot sync --dry-run`.
+
 ## Making it yours
 
 Everything here is policy except a handful of identity values a copier edits:
@@ -36,10 +38,12 @@ Everything else is policy, not identity — copy it as-is.
 |---------|-----|
 | `dot sync` | Idempotent re-sync. Installs missing tools, recreates broken symlinks. Fast on no-op. |
 | `dot sync --upgrade` | Same + brew update/upgrade/cleanup + mise upgrade. |
-| `dot sync --only=brew,mise` | Only the listed sections (tags: `brew mise sheldon symlinks ssh claude lefthook macos`). |
+| `dot sync --only=brew,mise` | Only the listed sections (tags: `brew mise sheldon symlinks ssh claude lefthook macos`). A tag no module declares fails loudly (exit 1), not silently. |
+| `dot sync --dry-run` | Mutate nothing; print what each module *would* do. Safe on a fresh machine. |
 | `dot update` | Bump everything to current — equivalent to `dot sync --upgrade`. |
-| `dot doctor` | Read-only diagnostics: tool presence, symlink integrity (missing *and* orphaned), drift. Exits non-zero on failures. |
+| `dot doctor` | Read-only diagnostics: tool presence, symlink integrity (missing *and* orphaned), drift. Exit codes: `0` clean, `1` failures, `2` warnings only. |
 | `dot doctor --fix` | Same diagnostics, plus repair the symlink contract: reap orphaned symlinks *and* relink any entry that's missing, a non-symlink file, or pointing at the wrong target (doctor's only mutation). |
+| `dot doctor --full` | Same diagnostics, plus a full-history `gitleaks` scan of the repo (slow; on-demand). |
 
 ## What's here
 
@@ -65,7 +69,10 @@ Everything else is policy, not identity — copy it as-is.
 | `Brewfile` | `brew "mise"` + casks (GUI apps, fonts). All dev CLIs live in mise.toml. |
 | `mise.toml` | Language toolchains + every dev CLI. Single update path via `mise upgrade`. |
 | `sheldon/plugins.toml` | Zsh plugin config |
-| `lefthook.yml` | Pre-commit lint gate (shellcheck + shfmt + gitleaks) for this repo |
+| `lefthook.yml` | Pre-commit lint gate (shellcheck + shfmt + gitleaks) + commit-msg WIP guard for this repo |
+| `test/` | `bats` unit tests for `lib/common.sh` (run in CI and via `mise x -- bats test/`) |
+| `.github/workflows/lint.yml` | CI: shellcheck + shfmt + gitleaks + bats on push to `main` and PRs |
+| `LICENSE` | MIT |
 
 ## Claude Code integration
 
@@ -73,12 +80,16 @@ Everything else is policy, not identity — copy it as-is.
 
 - `CLAUDE.md` — user-level global instructions
 - `settings.json` — deliberately minimal (agent teams, statusline, auto mode, quieter UI); the full list lives in `dot-claude/CLAUDE.md`
+- `REFERENCE.md` — a load-on-demand Claude Code cheatsheet (built-in slash commands, experimental env vars). Not symlinked into `~/.claude/` and not auto-loaded — read it when you need it.
 
 The statusline is a separate project — [claude-statusline](https://github.com/alxjrvs/claude-statusline). `dot sync` (claude tag) clones it to `~/Code/claude-statusline` (fast-forwards an existing clone) and runs its `install.sh`, which symlinks both scripts into `~/.local/bin`; `settings.json` references the installed path. `dot doctor` checks the symlinks are present.
 
-## Linting
+## Linting & tests
 
-`lefthook.yml` runs a pre-commit gate on staged shell files: `shellcheck`, `shfmt -i 2 -ci -sr`, `gitleaks protect`, and a `settings.json` validity check. `dot sync` installs the hooks. No test suite and no CI — this is a personal repo; the lint gate is the only automation.
+- **pre-commit** (`lefthook.yml`, installed by `dot sync`): `shellcheck`, `shfmt -i 2 -ci -sr`, `gitleaks protect`, and a `settings.json` validity check on staged shell files.
+- **commit-msg** (`lefthook.yml`): rejects throwaway subjects (bare `WIP` or a single character). Convention: `scope: summary` / `type(scope): summary`. Bypass once with `git commit --no-verify`.
+- **CI** (`.github/workflows/lint.yml`): the same lint set plus `bats` unit tests, on push to `main` and PRs. Lint only — never runs `dot sync`.
+- **tests** (`test/`): `bats` coverage of the `lib/common.sh` helpers (`link`, `os_kind`, `resolve_dotfiles_dir`). Run with `mise x -- bats test/`.
 
 ## Git signing
 

--- a/doctor
+++ b/doctor
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # doctor — dotfiles health check. Read-only by default.
-# Exits non-zero when any hard failure is found.
+#
+# Exit codes (so callers — CI, bootstrap, cron — can act on the result):
+#   0   clean: no failures, no warnings
+#   1   one or more hard failures
+#   2   warnings only (degraded but not broken: symlink drift, brew/mise drift,
+#       unconfigured signing, …). Distinct from 0 so "clean" is machine-checkable.
 #
 # Flags:
 #   --fix   Repair the symlink contract — doctor's only mutation. Two parts:
@@ -11,6 +16,9 @@
 #                (overwrite: rm + relink, no backup — canonical content is here).
 #           Non-symlink drift (brew/mise/macos) keeps its read-only
 #           "run dot sync --only=X" hint.
+#   --full  Also run a full-history secret scan (gitleaks detect) over the
+#           dotfiles repo. Off by default because it's slow; the pre-commit
+#           hook already guards new commits.
 #
 # Honors DOTFILES_DOCTOR_SKIP_EXTERNAL=1 to skip slow/network-bound checks
 # (brew bundle drift, gh auth).
@@ -45,11 +53,16 @@ source "${_DOCTOR_DIR}/install/40-symlinks.sh"
 
 # ── Flags ─────────────────────────────────────────────────────────────────────
 _FIX=0
+_FULL=0
 for _arg in "$@"; do
   case "$_arg" in
     --fix) _FIX=1 ;;
+    --full) _FULL=1 ;;
     -h | --help)
-      printf 'usage: doctor [--fix]\n  --fix   repair symlinks: reap orphans + relink missing/incorrect (default: read-only)\n'
+      printf 'usage: doctor [--fix] [--full]\n'
+      printf '  --fix    repair symlinks: reap orphans + relink missing/incorrect (default: read-only)\n'
+      printf '  --full   also run a full-history gitleaks scan of the repo (slow)\n'
+      printf '  exit codes: 0 clean, 1 failures, 2 warnings only\n'
       exit 0
       ;;
     *)
@@ -65,18 +78,20 @@ _FAILS=0
 _WARNS=0
 _FIXED=0
 
-_ok() { printf '\033[0;32m  \xe2\x9c\x93 %s\033[0m\n' "$*"; }
+# Output: _ok is the shared pure printer (from lib/common.sh). _warn/_fail/_fixed
+# wrap the shared raw printers (_p_*) to also tally the counters that drive the
+# exit code — so the ANSI strings still live in exactly one place (lib/common.sh).
 _warn() {
-  printf '\033[0;33m  \xe2\x86\x92 %s\033[0m\n' "$*"
+  _p_warn "$*"
   _WARNS=$((_WARNS + 1))
 }
 _fail() {
-  printf '\033[0;31m  \xe2\x9c\x97 %s\033[0m\n' "$*" >&2
+  _p_fail "$*"
   _FAILS=$((_FAILS + 1))
 }
 # _fixed — a mutation doctor performed under --fix (cyan wrench).
 _fixed() {
-  printf '\033[0;36m  \xe2\x9c\x82 %s\033[0m\n' "$*"
+  _p_fixed "$*"
   _FIXED=$((_FIXED + 1))
 }
 
@@ -233,7 +248,7 @@ else
     unset _brewfile
   fi
 fi
-unset _dotfiles
+# NB: _dotfiles is resolved once (above) and reused through §7 — don't unset here.
 
 # ── 5. gh auth status (external) ─────────────────────────────────────────────
 if [[ -z "$skip_external" ]]; then
@@ -260,9 +275,9 @@ fi
 unset _mise_missing _missing_count
 
 # ── 7. lefthook hook installed ────────────────────────────────────────────────
-_dotfiles2=$(resolve_dotfiles_dir 2> /dev/null || true)
-if [[ -n "$_dotfiles2" ]]; then
-  _lh_hook="${_dotfiles2}/.git/hooks/pre-commit"
+# Reuses _dotfiles resolved in §3 (single resolution across §3–§7).
+if [[ -n "$_dotfiles" ]]; then
+  _lh_hook="${_dotfiles}/.git/hooks/pre-commit"
   if [[ ! -f "$_lh_hook" ]]; then
     _warn "lefthook: pre-commit hook not installed in dotfiles repo — run \`lefthook install\`"
   else
@@ -274,7 +289,22 @@ if [[ -n "$_dotfiles2" ]]; then
   fi
   unset _lh_hook
 fi
-unset _dotfiles2
+
+# ── 7b. Full-history secret scan (opt-in, --full) ─────────────────────────────
+# The pre-commit hook guards new commits; this catches anything already in
+# history. Slow, so it only runs on demand.
+if [[ "$_FULL" -eq 1 ]]; then
+  if [[ -z "$_dotfiles" ]]; then
+    _warn "gitleaks --full: dotfiles repo not found — skipping"
+  elif ! command -v gitleaks > /dev/null 2>&1; then
+    _warn "gitleaks --full: gitleaks not on PATH — run \`dot sync --only=mise\`"
+  elif gitleaks detect --source "$_dotfiles" --redact --no-banner > /dev/null 2>&1; then
+    _ok "gitleaks: full-history scan clean"
+  else
+    _fail "gitleaks: full-history scan found leaks — run \`gitleaks detect --source ${_dotfiles} -v\`"
+  fi
+fi
+unset _dotfiles
 
 # ── 8. Claude statusline (separate repo, installed to ~/.local/bin) ──────────
 if [[ -L "${HOME}/.local/bin/claude-statusline" && -L "${HOME}/.local/bin/claude-subagent-statusline" ]]; then
@@ -351,14 +381,33 @@ else
 fi
 unset _eff_key
 
+# ── 11. SSH ControlPath socket dir (must be user-private) ────────────────────
+# ssh/config keeps multiplexing sockets under ~/.ssh/cm (not world-writable
+# /tmp). If the dir exists it must be 700, or another local user could race it.
+_cmdir="${HOME}/.ssh/cm"
+if [[ -d "$_cmdir" ]]; then
+  _perms=$(stat -f '%Lp' "$_cmdir" 2> /dev/null || true)
+  if [[ "$_perms" == "700" ]]; then
+    _ok "ssh ControlPath dir ~/.ssh/cm is 700"
+  else
+    _warn "ssh ControlPath dir ~/.ssh/cm is ${_perms:-unknown}, expected 700 — run: chmod 700 ~/.ssh/cm"
+  fi
+  unset _perms
+fi
+unset _cmdir
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 printf '\n'
 [[ "$_FIXED" -gt 0 ]] && printf '\033[0;36m  \xe2\x9c\x82 repaired %d symlink issue(s)\033[0m\n' "$_FIXED"
 if [[ "$_FAILS" -eq 0 && "$_WARNS" -eq 0 ]]; then
   _ok "All checks passed"
+  exit 0
 elif [[ "$_FAILS" -eq 0 ]]; then
-  printf '\033[0;33m  \xe2\x86\x92 %d warning(s) — see above\033[0m\n' "$_WARNS"
+  # Warnings only — degraded but not broken. Exit 2 so "clean" is distinct from
+  # "drifted" for any caller that checks the status (CI, bootstrap, cron).
+  _p_warn "$_WARNS warning(s) — see above (degraded, not broken)"
+  exit 2
 else
-  printf '\033[0;31m  \xe2\x9c\x97 %d error(s), %d warning(s)\033[0m\n' "$_FAILS" "$_WARNS" >&2
+  _p_fail "$_FAILS error(s), $_WARNS warning(s)"
   exit 1
 fi

--- a/dot-claude/CLAUDE.md
+++ b/dot-claude/CLAUDE.md
@@ -14,7 +14,7 @@ Settings (`~/.claude/settings.json`, symlinked from the dotFiles repo) are minim
 - Agents view disabled (`disableAgentView: true`) — turns off the `claude agents` view / `--bg` / `/background` on-demand dispatch. Independent of Agent teams above (teams stay on; only the view is off).
 - Quieter UI (`showTurnDuration: false`, `terminalProgressBarEnabled: false`) — no per-turn duration line, no terminal progress bar
 - Custom statusline (`~/.local/bin/claude-statusline`, from the separate `claude-statusline` repo)
-- Auto permission mode (`permissions.defaultMode`)
+- Auto permission mode (`permissions.defaultMode`) — a deliberate productivity tradeoff: it auto-approves tool calls, removing the per-call human gate. Accepted risk, but **re-evaluate periodically** — it removes the safety net against prompt injection / confused-deputy scenarios, and the user-scope GitHub MCP server widens that surface across all projects. Scope down via a project-level `settings.local.json` for any repo that warrants it.
 - Commit attribution trailer + input-needed notifications
 - Claude's commit identity (`env` `GIT_AUTHOR_*`/`GIT_COMMITTER_*` → `Claude <alxjrvs+claude@gmail.com>`, `GIT_CONFIG_*` → `commit.gpgsign=false`): commits Claude makes are authored under a distinct, unsigned identity so they never need a 1Password unlock, while your own terminal git (and `gh`) keep `alxjrvs` + 1Password signing. The `attribution.commit` trailer credits you as co-author. Add `alxjrvs+claude@gmail.com` on GitHub to link these commits to your profile.
 

--- a/dot-claude/settings.json
+++ b/dot-claude/settings.json
@@ -37,6 +37,14 @@
     "toolkit@gnar": true,
     "typescript-lsp@claude-plugins-official": true
   },
+  "extraKnownMarketplaces": {
+    "gnar": {
+      "source": {
+        "source": "github",
+        "repo": "thegnarco/agent-skills"
+      }
+    }
+  },
   "skipWorkflowUsageWarning": true,
   "showTurnDuration": false,
   "terminalProgressBarEnabled": false,

--- a/git-template/hooks/pre-commit
+++ b/git-template/hooks/pre-commit
@@ -13,6 +13,14 @@
 
 set -e
 
-if command -v gitleaks > /dev/null 2>&1; then
-  gitleaks protect --staged --redact -v --no-banner
+# Fail loudly when gitleaks is absent rather than silently no-op'ing — a
+# partially-provisioned machine should not commit unscanned code. On a synced
+# machine gitleaks is on PATH (mise shims via .zshenv), so this never trips.
+if ! command -v gitleaks > /dev/null 2>&1; then
+  printf 'pre-commit: gitleaks not on PATH — cannot scan staged changes for secrets.\n' >&2
+  printf '  Provision it with:  dot sync   (or: mise install)\n' >&2
+  printf '  Bypass for one commit (only if you are sure):  git commit --no-verify\n' >&2
+  exit 1
 fi
+
+gitleaks protect --staged --redact -v --no-banner

--- a/install/00-brew.sh
+++ b/install/00-brew.sh
@@ -13,10 +13,19 @@ _brew_run() {
 
   printf '\n==> Homebrew\n'
 
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    printf '\033[0;36m  ~ [dry-run] would ensure Homebrew and run brew bundle (--upgrade also updates/upgrades/cleans)\033[0m\n'
+    return 0
+  fi
+
   if command -v brew > /dev/null 2>&1; then
     printf '\033[0;32m  \xe2\x9c\x93 Homebrew installed\033[0m\n'
   else
     printf '\033[0;33m  \xe2\x86\x92 Installing Homebrew...\033[0m\n'
+    # Accepted residual risk: the upstream installer is piped to bash without a
+    # checksum. Homebrew publishes no stable per-release hash for install.sh (the
+    # HEAD URL moves), so pinning isn't possible; trust is anchored in HTTPS +
+    # GitHub. Runs once on a fresh machine, only when `brew` is absent.
     bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
 

--- a/install/30-mise.sh
+++ b/install/30-mise.sh
@@ -13,6 +13,11 @@ _mise_run() {
 
   printf '\n==> mise tools\n'
 
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    printf '\033[0;36m  ~ [dry-run] would run mise install (+ upgrade) and sheldon lock --update\033[0m\n'
+    return 0
+  fi
+
   # Pin mise to the repo's mise.toml explicitly. Nothing in
   # bootstrap.sh -> dot -> sync chdirs to the repo, so CWD-based config
   # discovery finds nothing on a fresh machine. MISE_CONFIG_FILE forces

--- a/install/40-symlinks.sh
+++ b/install/40-symlinks.sh
@@ -9,6 +9,10 @@ _symlinks_tags() { printf 'symlinks\n'; }
 
 # _symlink_pairs: emit "src|dst" lines — src relative to the repo, dst relative
 # to $HOME. This list IS the symlink contract.
+#
+# Public API: consumed by both _symlinks_run() here (apply) and doctor (audit +
+# --fix), which sources this module and reads _symlink_pairs to check/repair the
+# exact set this applies. Keep the "src|dst" output shape stable.
 _symlink_pairs() {
   cat << 'PAIRS'
 .zshrc|.zshrc
@@ -58,7 +62,13 @@ _symlinks_run() {
     link "${df}/${src}" "${HOME}/${dst}"
   done < <(_symlink_pairs)
 
-  # SSH needs tight perms.
-  chmod 700 "${HOME}/.ssh" 2> /dev/null || true
-  chmod 600 "${HOME}/.ssh/config" 2> /dev/null || true
+  # SSH needs tight perms. Skipped under --dry-run (these create/chmod ~/.ssh).
+  if [[ "${DRY_RUN:-0}" != "1" ]]; then
+    chmod 700 "${HOME}/.ssh" 2> /dev/null || true
+    chmod 600 "${HOME}/.ssh/config" 2> /dev/null || true
+    # ControlMaster sockets live here (ssh/config: ControlPath ~/.ssh/cm/%C),
+    # kept out of world-writable /tmp. Must stay user-private (doctor checks 700).
+    mkdir -p "${HOME}/.ssh/cm"
+    chmod 700 "${HOME}/.ssh/cm" 2> /dev/null || true
+  fi
 }

--- a/install/45-ssh.sh
+++ b/install/45-ssh.sh
@@ -10,10 +10,6 @@
 
 _ssh_tags() { printf 'ssh\n'; }
 
-_OP_AGENT_SOCK="${HOME}/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
-_OP_SSH_SIGN="/Applications/1Password.app/Contents/MacOS/op-ssh-sign"
-_SIGNING_KEY_NAME="GitHubSSH"
-
 # Read the signing key's public line from the 1Password agent and echo just
 # "<type> <data>" (no comment). Empty if the agent is down or the key absent.
 _ssh_signing_pubkey() {
@@ -27,6 +23,20 @@ _ssh_signing_pubkey() {
 
 _ssh_run() {
   printf '\n==> SSH signing (1Password / op-ssh-sign)\n'
+
+  # Config constants, assigned at run time (not module-source time) so sourcing
+  # this module has no side effects — consistent with every other install
+  # module. Plain (not `local`) so _ssh_signing_pubkey, called below, sees them
+  # via bash dynamic scope. Customize the 1Password signing-key item name here:
+  _SIGNING_KEY_NAME="GitHubSSH"
+  _OP_AGENT_SOCK="${HOME}/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+  _OP_SSH_SIGN="/Applications/1Password.app/Contents/MacOS/op-ssh-sign"
+
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    printf '\033[0;36m  ~ [dry-run] would converge signing in ~/.gitconfig.local + ~/.ssh/allowed_signers\033[0m\n'
+    return 0
+  fi
+
   mkdir -p "${HOME}/.ssh"
   chmod 700 "${HOME}/.ssh" 2> /dev/null || true
 

--- a/install/60-claude.sh
+++ b/install/60-claude.sh
@@ -57,19 +57,35 @@ _claude_install_statusline() {
       return 0
     fi
   fi
-  if [[ -x "${dir}/install.sh" ]] && "${dir}/install.sh" > /dev/null 2>&1; then
+  if [[ ! -x "${dir}/install.sh" ]]; then
+    printf '\033[0;33m  \xe2\x86\x92 claude-statusline: install.sh missing or not executable — skipping\033[0m\n' >&2
+  elif "${dir}/install.sh" > /dev/null 2>&1; then
     printf '\033[0;32m  \xe2\x9c\x93 claude-statusline installed (~/.local/bin)\033[0m\n'
+  else
+    # Don't let a failed install.sh read as success — sync printed nothing here
+    # before, leaving ~/.local/bin/claude-statusline silently absent.
+    printf '\033[0;33m  \xe2\x86\x92 claude-statusline: install.sh failed — run "%s/install.sh" manually\033[0m\n' "${dir}" >&2
   fi
 }
 
 _claude_run() {
   printf '\n==> Claude Code\n'
+
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    printf '\033[0;36m  ~ [dry-run] would install Claude Code CLI (if absent), register github MCP, install claude-statusline\033[0m\n'
+    return 0
+  fi
+
   if command -v claude > /dev/null 2>&1; then
     local ver
     ver=$(claude --version 2> /dev/null | head -1 || true)
     printf '\033[0;32m  \xe2\x9c\x93 Claude Code CLI installed (%s)\033[0m\n' "$ver"
   else
     printf '\033[0;33m  \xe2\x86\x92 Installing Claude Code CLI (native installer)...\033[0m\n'
+    # Accepted residual risk: the installer is piped to bash without a checksum.
+    # Upstream publishes no stable per-release hash for install.sh, so pinning
+    # isn't possible; trust is anchored in HTTPS to claude.ai. Runs once, only
+    # when `claude` is absent.
     if bash -c "$(curl -fsSL https://claude.ai/install.sh)"; then
       printf '\033[0;32m  \xe2\x9c\x93 Claude Code CLI installed\033[0m\n'
     else

--- a/install/85-lefthook.sh
+++ b/install/85-lefthook.sh
@@ -8,6 +8,12 @@ _lefthook_tags() { printf 'lefthook\n'; }
 
 _lefthook_run() {
   printf '\n==> Lefthook (this repo)\n'
+
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    printf '\033[0;36m  ~ [dry-run] would run lefthook install in %s\033[0m\n' "${DOTFILES_DIR}"
+    return 0
+  fi
+
   if ! command -v lefthook > /dev/null 2>&1; then
     printf '\033[0;33m  \xe2\x86\x92 lefthook not found — should have been installed by mise (mise.toml)\033[0m\n'
     return 0

--- a/install/90-macos.sh
+++ b/install/90-macos.sh
@@ -54,6 +54,11 @@ _macos_run() {
 
   printf '\n==> macOS defaults\n'
 
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    printf '\033[0;36m  ~ [dry-run] would write %d macOS defaults and restart Dock/Finder\033[0m\n' "${#_MACOS_DEFAULTS[@]}"
+    return 0
+  fi
+
   local applied=0
   local entry domain key kind raw flag
   for entry in "${_MACOS_DEFAULTS[@]}"; do
@@ -88,6 +93,10 @@ _macos_run() {
 #   "match|domain|key"            — actual == expected
 #   "drift|domain|key|expected|actual"
 #   "missing|domain|key|expected"
+#
+# Public API: doctor sources this module and calls macos_audit() directly (§9)
+# to render the read-only drift report — so its output contract (the lines
+# above) is consumed outside this file; keep it stable.
 macos_audit() {
   if [[ "$(os_kind)" != "darwin" ]]; then
     return 0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,10 +12,10 @@ pre-commit:
   commands:
     shellcheck:
       # `*.sh` matches recursively; the extensionless entrypoints are listed explicitly.
-      glob: "{*.sh,dot,sync,doctor,git-template/hooks/*}"
+      glob: "{*.sh,dot,sync,doctor,watchtower,git-template/hooks/*}"
       run: shellcheck -x {staged_files}
     shfmt-check:
-      glob: "{*.sh,dot,sync,doctor,git-template/hooks/*}"
+      glob: "{*.sh,dot,sync,doctor,watchtower,git-template/hooks/*}"
       # -d prints a unified diff and exits nonzero — won't auto-rewrite on commit
       run: shfmt -d -i 2 -ci -sr {staged_files}
     gitleaks:
@@ -24,3 +24,17 @@ pre-commit:
       # Backstop against committing a broken settings.json (breaks every Claude session).
       glob: "dot-claude/settings*.json"
       run: jq -e . {staged_files} > /dev/null
+
+# commit-msg: forward-only hygiene guard. Rejects throwaway subjects (bare
+# "WIP"/"wip" or a single character) so they don't land in permanent history.
+# Existing history is untouched. Convention: `scope: summary` or
+# `type(scope): summary` (see CLAUDE.md). Bypass once with: git commit --no-verify
+commit-msg:
+  commands:
+    no-wip:
+      run: |
+        subject=$(head -1 "{1}")
+        if printf '%s' "$subject" | grep -qiE '^(wip|.)$'; then
+          printf 'commit-msg: refusing throwaway subject "%s" — write a real summary (bypass: --no-verify)\n' "$subject" >&2
+          exit 1
+        fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -9,6 +9,27 @@
 # symlinks with identical semantics — a single source of truth for the one
 # operation that deletes files at the destination.
 
+# ── Output palette ────────────────────────────────────────────────────────────
+# Single source of the ANSI color/glyph strings, shared by the standalone
+# scripts (doctor, watchtower). The `_p_*` functions are the raw printers — the
+# escape sequences live here exactly once. The unprefixed names are what scripts
+# call: watchtower uses them as-is; doctor re-wraps _warn/_fail/_fixed to also
+# bump its counters (it needs the totals for its exit code — see doctor).
+_p_hdr() { printf '\n\033[1m==> %s\033[0m\n' "$*"; }
+_p_ok() { printf '\033[0;32m  \xe2\x9c\x93 %s\033[0m\n' "$*"; }
+_p_warn() { printf '\033[0;33m  \xe2\x86\x92 %s\033[0m\n' "$*"; }
+_p_fail() { printf '\033[0;31m  \xe2\x9c\x97 %s\033[0m\n' "$*" >&2; }
+_p_fixed() { printf '\033[0;36m  \xe2\x9c\x82 %s\033[0m\n' "$*"; }
+_p_note() { printf '    %s\n' "$*"; }
+
+_hdr() { _p_hdr "$@"; }
+_ok() { _p_ok "$@"; }
+_warn() { _p_warn "$@"; }
+_fail() { _p_fail "$@"; }
+_crit() { _p_fail "$@"; } # watchtower's name for a red-x line
+_fixed() { _p_fixed "$@"; }
+_note() { _p_note "$@"; }
+
 # os_kind: "darwin" | "linux" | "unknown"
 os_kind() {
   case "$(uname -s)" in
@@ -47,6 +68,18 @@ link() {
       printf '\033[2m  - %s already linked\033[0m\n' "$label"
       return 0
     fi
+  fi
+
+  # Dry-run: report the action that WOULD be taken and mutate nothing. Must sit
+  # ahead of the create-if-missing branch below — LINK_MODE=skip does NOT stop
+  # that branch from creating a missing link, so this is the only safe gate.
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    if [[ ! -e "$dst" && ! -L "$dst" ]]; then
+      printf '\033[0;36m  ~ %s would be linked\033[0m\n' "$label"
+    else
+      printf '\033[0;36m  ~ %s exists and is not our symlink — would resolve via LINK_MODE\033[0m\n' "$label"
+    fi
+    return 0
   fi
 
   if [[ ! -e "$dst" && ! -L "$dst" ]]; then

--- a/mise.toml
+++ b/mise.toml
@@ -44,6 +44,9 @@ eza = "latest"
 shfmt = "latest"
 shellcheck = "latest"
 
+# ── Test runner (lib/common.sh unit tests in test/, also run in CI) ───
+bats = "latest"
+
 # ── Neovim language servers (nvim/init.lua wires these in) ────────────
 # rust-analyzer is not global — it comes with a per-project `rust` toolchain,
 # and nvim/init.lua picks it up automatically when present.

--- a/ssh/config
+++ b/ssh/config
@@ -15,8 +15,10 @@ Host *
 
   # Connection multiplexing — second `git push` reuses the first connection.
   ControlMaster auto
-  # Sockets live in /tmp (user-private 600) — avoids ~/.ssh/ if its perms ever drift.
-  ControlPath /tmp/ssh-cm-%r@%h:%p
+  # Sockets live under ~/.ssh/cm (user-private 700, created by `dot sync`), not
+  # world-writable /tmp — which is a symlink-race surface on multi-user hosts.
+  # %C is a hash of (local host, remote host, port, user): short, collision-free.
+  ControlPath ~/.ssh/cm/%C
   # 4h: repeated pushes in a work session reuse one authenticated connection,
   # so the 1Password agent isn't re-consulted.
   ControlPersist 4h

--- a/sync
+++ b/sync
@@ -2,13 +2,15 @@
 # sync — dotfiles installer/syncer.
 #
 # Usage:
-#   sync [--upgrade] [--only=tag1,tag2] [-f|--force] [-s|--skip]
+#   sync [--upgrade] [--only=tag1,tag2] [-f|--force] [-s|--skip] [--dry-run]
 #
 # Flags:
 #   --upgrade         brew update/upgrade/cleanup + mise upgrade
 #   --only=TAGS       comma-separated tag filter; only matching steps run
 #   -f, --force       LINK_MODE=overwrite (replace on conflict)
 #   -s, --skip        LINK_MODE=skip (leave conflicts untouched)
+#   --dry-run         mutate nothing — print what each module WOULD do. Safe to
+#                     run on a fresh machine; writes no files outside the repo.
 #   default           LINK_MODE=interactive (prompt on conflict)
 
 set -euo pipefail
@@ -68,6 +70,7 @@ unset _mise_shims
 SYNC_UPGRADE=0
 SYNC_ONLY_TAGS=""
 LINK_MODE="interactive"
+DRY_RUN=0
 
 for _arg in "$@"; do
   case "$_arg" in
@@ -84,11 +87,18 @@ for _arg in "$@"; do
     -s | --skip)
       LINK_MODE="skip"
       ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
   esac
 done
 unset _arg
 
-export SYNC_UPGRADE SYNC_ONLY_TAGS LINK_MODE
+export SYNC_UPGRADE SYNC_ONLY_TAGS LINK_MODE DRY_RUN
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  printf '\033[0;36m==> ~ dry run — no changes will be made\033[0m\n'
+fi
 
 # ── Acquire lock ──────────────────────────────────────────────────────────────
 acquire_lock "${TMPDIR:-/tmp}/dotfiles-sync.lock"

--- a/test/common.bats
+++ b/test/common.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# Unit tests for lib/common.sh — the shared helpers (os_kind, resolve_dotfiles_dir,
+# link) that both sync and doctor depend on. Run locally with `mise x -- bats test/`
+# or `bats test/`; also run in CI (.github/workflows/lint.yml).
+
+setup() {
+  REPO="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  # shellcheck source=../lib/common.sh
+  source "${REPO}/lib/common.sh"
+  TMP="$(mktemp -d "${BATS_TMPDIR:-/tmp}/common.XXXXXX")"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "os_kind matches the running platform" {
+  case "$(uname -s)" in
+    Darwin) expected=darwin ;;
+    Linux) expected=linux ;;
+    *) expected=unknown ;;
+  esac
+  run os_kind
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "resolve_dotfiles_dir honors \$DOTFILES_DIR when it holds a Brewfile" {
+  mkdir -p "$TMP/df"
+  touch "$TMP/df/Brewfile"
+  DOTFILES_DIR="$TMP/df" run resolve_dotfiles_dir
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TMP/df" ]
+}
+
+@test "resolve_dotfiles_dir rejects a dir without a Brewfile sentinel" {
+  mkdir -p "$TMP/nope" "$TMP/home"
+  DOTFILES_DIR="$TMP/nope" _DOTFILES_SELF_DIR="" HOME="$TMP/home" run resolve_dotfiles_dir
+  [ "$status" -ne 0 ]
+}
+
+@test "link creates a missing symlink" {
+  echo content > "$TMP/src"
+  run link "$TMP/src" "$TMP/dst"
+  [ "$status" -eq 0 ]
+  [ -L "$TMP/dst" ]
+  [ "$(readlink "$TMP/dst")" = "$TMP/src" ]
+}
+
+@test "link is idempotent on an already-correct symlink" {
+  echo content > "$TMP/src"
+  ln -s "$TMP/src" "$TMP/dst"
+  run link "$TMP/src" "$TMP/dst"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already linked"* ]]
+}
+
+@test "link skips a conflicting file in skip mode" {
+  echo existing > "$TMP/dst"
+  echo content > "$TMP/src"
+  LINK_MODE=skip run link "$TMP/src" "$TMP/dst"
+  [ "$status" -eq 0 ]
+  [ ! -L "$TMP/dst" ]
+  [ "$(cat "$TMP/dst")" = existing ]
+}
+
+@test "link overwrites a conflicting file in overwrite mode" {
+  echo existing > "$TMP/dst"
+  echo content > "$TMP/src"
+  LINK_MODE=overwrite run link "$TMP/src" "$TMP/dst"
+  [ "$status" -eq 0 ]
+  [ -L "$TMP/dst" ]
+  [ "$(readlink "$TMP/dst")" = "$TMP/src" ]
+}
+
+@test "link --dry-run reports the action but creates nothing" {
+  echo content > "$TMP/src"
+  DRY_RUN=1 run link "$TMP/src" "$TMP/dst"
+  [ "$status" -eq 0 ]
+  [ ! -e "$TMP/dst" ]
+  [[ "$output" == *"would be linked"* ]]
+}

--- a/watchtower
+++ b/watchtower
@@ -35,12 +35,12 @@
 
 set -euo pipefail
 
-# ── Output helpers (match doctor's palette) ───────────────────────────────────
-_hdr() { printf '\n\033[1m==> %s\033[0m\n' "$*"; }
-_ok() { printf '\033[0;32m  \xe2\x9c\x93 %s\033[0m\n' "$*"; }
-_warn() { printf '\033[0;33m  \xe2\x86\x92 %s\033[0m\n' "$*"; }
-_crit() { printf '\033[0;31m  \xe2\x9c\x97 %s\033[0m\n' "$*"; }
-_note() { printf '    %s\n' "$*"; }
+# ── Shared output palette (_hdr/_ok/_warn/_crit/_note) ────────────────────────
+# Sourced from lib/common.sh so the ANSI strings live in exactly one place.
+_WATCHTOWER_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/common.sh
+_DOTFILES_SELF_DIR="$_WATCHTOWER_DIR"
+source "${_WATCHTOWER_DIR}/lib/common.sh"
 
 # ── Flags ─────────────────────────────────────────────────────────────────────
 _VAULT=""
@@ -142,6 +142,7 @@ _withpw=$(awk -F'\t' '$7!="true" && $8!=""' "$DATA" | wc -l | tr -d ' ')
 
 # ── 2. Breached (Have-I-Been-Pwned, k-anonymity over unique non-dev hashes) ───
 _BRK="${_TMP}/breach.tsv"
+_BRKFAIL="${_TMP}/breach.failed" # sentinel: HIBP unreachable for ≥1 hash
 : > "$_BRK"
 if [[ "$_BREACH" -eq 1 ]]; then
   printf '  checking Have-I-Been-Pwned...\n' >&2
@@ -149,27 +150,43 @@ if [[ "$_BREACH" -eq 1 ]]; then
     [[ -z "$_h" ]] && continue
     _pre="${_h:0:5}"
     _suf="${_h:5}"
-    # NB: no early `exit` in awk — exiting closes the pipe, curl takes SIGPIPE,
-    # and under pipefail that non-zero status would clobber a real match to "".
-    _cnt=$(curl -s --max-time 10 "https://api.pwnedpasswords.com/range/${_pre}" < /dev/null |
-      tr -d '\r' | awk -F: -v s="$_suf" 'toupper($1)==s{print $2}') || _cnt=""
+    # Capture curl on its own so a network error (curl exits non-zero) is
+    # distinguished from a clean "no match". Folding both into one pipeline made
+    # an outage look like every password was un-breached — a false clean. On
+    # failure, drop a sentinel (the loop is a pipeline subshell, so a shell var
+    # wouldn't survive) and skip this hash. NB: no early `exit` in the suffix
+    # awk — exiting closes the pipe and would surface as a spurious error.
+    if ! _resp=$(curl -s --max-time 10 "https://api.pwnedpasswords.com/range/${_pre}" < /dev/null); then
+      : > "$_BRKFAIL"
+      continue
+    fi
+    _cnt=$(printf '%s' "$_resp" | tr -d '\r' | awk -F: -v s="$_suf" 'toupper($1)==s{print $2}')
+    # `if` (no else) returns 0 when there's no match, so the loop body never
+    # trips errexit on its last command — no `|| true` masking needed.
     if [[ -n "$_cnt" ]]; then
       printf '%s\t%s\n' "$_h" "$_cnt" >> "$_BRK"
     fi
-  done || true
+  done
 fi
 
 # ── 3. Report ─────────────────────────────────────────────────────────────────
 _hdr "Breached passwords (Have-I-Been-Pwned)"
 if [[ "$_BREACH" -eq 0 ]]; then
   _note "(skipped — --no-breach)"
-elif [[ -s "$_BRK" ]]; then
-  while IFS=$'\t' read -r _h _cnt; do
-    _crit "password in ${_cnt} known breaches:"
-    awk -F'\t' -v H="$_h" '$7!="true" && $8==H{printf "    [%s] %s  (%s)\n",$1,$2,$3}' "$DATA"
-  done < "$_BRK"
 else
-  _ok "none of your passwords appear in HiBP"
+  if [[ -s "$_BRK" ]]; then
+    while IFS=$'\t' read -r _h _cnt; do
+      _crit "password in ${_cnt} known breaches:"
+      awk -F'\t' -v H="$_h" '$7!="true" && $8==H{printf "    [%s] %s  (%s)\n",$1,$2,$3}' "$DATA"
+    done < "$_BRK"
+  elif [[ ! -f "$_BRKFAIL" ]]; then
+    # Only a true all-clean (every hash checked, none matched) earns this line.
+    _ok "none of your passwords appear in HiBP"
+  fi
+  # A network failure for any hash means the result is incomplete — never let
+  # that read as "clean".
+  [[ -f "$_BRKFAIL" ]] &&
+    _warn "HIBP breach check incomplete — could not reach api.pwnedpasswords.com for some passwords; results are partial"
 fi
 unset _h _cnt
 

--- a/zsh/30-plugins.zsh
+++ b/zsh/30-plugins.zsh
@@ -1,3 +1,10 @@
+# Startup baseline (measured 2026-06-13, Apple Silicon): `zsh -i -c exit` ≈ 199 ms
+# avg over 10 runs. Per-eval breakdown: sheldon 59, atuin 47, starship 29,
+# mise 29, fzf 22, compinit 11 (ms). No single call is pathological; the only
+# ways to cut the two largest are dropping plugins (sheldon) or deferring atuin
+# init (loses instant Ctrl-R history) — both are UX tradeoffs, so the baseline
+# is accepted as-is. Re-measure with: zsh -i -c exit under `time`.
+
 # Homebrew completions
 fpath+=(/opt/homebrew/share/zsh/site-functions)
 


### PR DESCRIPTION
Implements every item from the gnar `audit:audit` remediation plan against this repo. All changes verified before commit: `shellcheck` clean, `shfmt` clean, 8/8 `bats` tests pass, `settings.json` valid, `dot doctor` exits 0, `dot sync --dry-run` confirmed non-mutating.

## What's in here

**Make failures visible (the dominant theme)**
- `doctor` exit codes: `0` clean / `1` failures / `2` warnings-only (N2)
- warn instead of silent success when `claude-statusline` install fails (N5)
- `watchtower` distinguishes an HIBP network error from a clean result — no false "none breached" (X3)
- global git-template pre-commit fails loudly when `gitleaks` is absent (X1)

**Security**
- SSH `ControlPath` moved out of world-writable `/tmp` → `~/.ssh/cm` (700) (X2)
- documented accepted residual risk on the `curl|bash` bootstraps (L1)
- `doctor --full`: on-demand full-history `gitleaks` scan (L9)
- re-evaluation note on `permissions.defaultMode: auto` (L2)

**Architecture / hygiene**
- shared output palette in `lib/common.sh`; `doctor` + `watchtower` source it (X4)
- consolidated `doctor`'s duplicate `resolve_dotfiles_dir` (L4)
- `45-ssh.sh` constants assigned at run time — no source-time side effects (L5)
- API-consumer comments on `_symlink_pairs` / `macos_audit` (L10)

**Verification / delivery**
- `sync --dry-run` — mutate nothing, print intended actions (L3)
- `bats` unit tests for `lib/common.sh` + `bats` in `mise.toml` (L6)
- GitHub Actions lint CI mirroring the pre-commit gate (X8)
- commit-msg WIP guard + documented commit convention (X7, L8)
- shell startup baseline recorded (~199ms); evaluated, no change warranted (L7)

**Docs / portfolio**
- MIT `LICENSE` (N1)
- README: last-tested line, `--dry-run`, accurate `--only` behavior, `REFERENCE.md`, CI/tests sections (N4, X5, X6)
- reconciled `CLAUDE.md`/README "no CI/tests" language with the new reality
- registered the gnar agent-skills marketplace in `settings.json`

**Remote** — 5 stale (>90-day) branches deleted from origin (N3, done out-of-band).

## Notes / deviations from the literal plan
- **X5 was a stale finding:** `sync` already fails loudly on an unknown `--only` tag, so I corrected the outdated gotcha rather than documenting a falsehood.
- **CI gitleaks uses `--no-git`** (current-tree scan) to avoid flaky failures on 600+ commits of history; deep history is covered on demand by `doctor --full`.
- **L7:** measured/profiled startup; no single call is pathological, so the baseline is recorded as-is rather than cutting plugin/atuin features.

After merge, run `dot sync --only=mise` on each machine to install the newly-pinned `bats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)