### PR TITLE
fix(zsh): stop fzf from silently overriding atuin's Ctrl-R binding

### DIFF
--- a/atuin/config.toml
+++ b/atuin/config.toml
@@ -17,6 +17,10 @@ inline_height = 20
 # ever run".
 filter_mode_shell_up_key_binding = "session"
 
+# Scope history search/cycling to the current repo (git root) rather than
+# globally — most Ctrl-R recall is "what did I run in this project".
+workspaces = true
+
 [sync]
 # Atuin sync v2 (encrypted record sync). Required for cross-machine history.
 records = true

--- a/zsh/00-exports.zsh
+++ b/zsh/00-exports.zsh
@@ -15,6 +15,10 @@ export TERMINAL=ghostty
 # resolves it on demand via `gh auth token` (the github MCP server reads its PAT
 # from 1Password through op-agent). See .zprofile for the rationale.
 
+# maestro (mobile UI testing) CLI on PATH. Harmless on machines without it —
+# a non-existent dir on PATH is a no-op.
+export PATH="$PATH:$HOME/.maestro/bin"
+
 # Colored man pages (CMYK)
 export LESS_TERMCAP_mb=$'\e[1;35m'
 export LESS_TERMCAP_md=$'\e[1;36m'

--- a/zsh/30-plugins.zsh
+++ b/zsh/30-plugins.zsh
@@ -11,9 +11,8 @@ fpath+=(/opt/homebrew/share/zsh/site-functions)
 # Sheldon plugins (adds zsh-completions to fpath, loads FSH last)
 eval "$(sheldon source)"
 
-# Atuin shell history — Ctrl-R fuzzy search. --disable-up-arrow keeps Up/Down as
-# plain zsh history navigation instead of opening atuin's search on every Up.
-eval "$(atuin init zsh --disable-up-arrow)"
+# Atuin shell history init lives in zsh/60-tools.zsh, after fzf's — both bind
+# Ctrl-R and fzf's must not win (see the comment there).
 
 # Syntax highlighting theme (Jack Kirby CMYK) - F-Sy-H overrides
 typeset -A FAST_HIGHLIGHT_STYLES

--- a/zsh/60-tools.zsh
+++ b/zsh/60-tools.zsh
@@ -1,9 +1,19 @@
 # fzf shell integration (modern)
 eval "$(fzf --zsh)"
+
+# Atuin shell history — Ctrl-R fuzzy search. Must load AFTER fzf: both bind
+# Ctrl-R and whichever inits last wins the binding; atuin's synced/encrypted
+# history is meant to be the source of truth (see zsh/10-options.zsh), so it
+# has to override fzf's plain-history binding here, not the reverse.
+# --disable-up-arrow keeps Up/Down as plain zsh history navigation instead of
+# opening atuin's search on every Up.
+eval "$(atuin init zsh --disable-up-arrow)"
+
 export FZF_DEFAULT_OPTS='--layout=reverse --border --height=40% --color=bg+:#3b4252,bg:#2e3440,spinner:#81a1c1,hl:#a3be8c,fg:#d8dee9,header:#a3be8c,info:#ebcb8b,pointer:#81a1c1,marker:#81a1c1,prompt:#81a1c1'
 export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git'
 export FZF_CTRL_T_OPTS="--preview 'bat --color=always {}' --preview-window right:50%"
 export FZF_ALT_C_OPTS="--preview 'eza --icons -T {} | head -20'"
+export FZF_ALT_C_COMMAND='fd --type d --hidden --follow --exclude .git'
 
 # zoxide — frecency `cd`. `z foo` jumps to the most-frecent dir matching "foo";
 # `zi foo` opens an fzf picker over matches (inherits FZF_DEFAULT_OPTS above).

--- a/zsh/95-maestro.zsh
+++ b/zsh/95-maestro.zsh
@@ -1,3 +1,0 @@
-# maestro (mobile UI testing) CLI on PATH. Harmless on machines without it —
-# a non-existent dir on PATH is a no-op.
-export PATH="$PATH:$HOME/.maestro/bin"


### PR DESCRIPTION
## Summary

- **The actual bug**: `zsh/30-plugins.zsh` initialized atuin (binding Ctrl-R) before `zsh/60-tools.zsh` initialized fzf, which also binds Ctrl-R and ran later — so fzf silently won the binding on every shell start. This meant atuin's synced/encrypted history (documented in `zsh/10-options.zsh` as the source of truth) was never actually being searched via Ctrl-R; users got plain local shell history via fzf instead.
- **Fix**: moved the `eval "$(atuin init zsh --disable-up-arrow)"` line out of `zsh/30-plugins.zsh` and into `zsh/60-tools.zsh`, placed immediately after `eval "$(fzf --zsh)"`, so atuin now initializes last and wins the Ctrl-R binding. Left a cross-reference comment in `30-plugins.zsh` pointing to the new location and the reason.
- Added `export FZF_ALT_C_COMMAND='fd --type d --hidden --follow --exclude .git'` in `zsh/60-tools.zsh` so Alt-C's directory jump uses fd (matching the existing fd-based Ctrl-T command and Alt-C preview) instead of falling back to plain `find`.
- Folded maestro's lone `PATH` export from `zsh/95-maestro.zsh` into `zsh/00-exports.zsh` and deleted the now-empty file.
- Added `workspaces = true` to `atuin/config.toml` to scope Ctrl-R history search/cycling to the current repo.

## ⚠️ Review notes — please do NOT auto-merge

This changes interactive shell behavior (which tool wins the Ctrl-R binding) on next terminal restart for every zsh session. It should get a manual smoke test — open a new terminal, hit Ctrl-R, and confirm it opens atuin's UI (not fzf's) — before merging. Flagging clearly: **manual review + terminal testing recommended, not just CI green.**

## Test plan
- [ ] Re-source shell (`exec zsh` or new terminal) and confirm Ctrl-R opens atuin's picker, not fzf's
- [ ] Confirm Ctrl-T (fzf file picker) still works as before
- [ ] Confirm Alt-C now jumps only into directories (via fd) with the eza preview
- [ ] Confirm `maestro` CLI is still on PATH (`which maestro`)
- [ ] Confirm atuin history search is now scoped to the current repo (`workspaces = true`)

Co-Authored-By: alxjrvs <alxjrvs+claude@gmail.com>