### PR TITLE
feat(git): reap gone branches alias, safer force-push

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -4,6 +4,7 @@
   sw = switch
   st = status -sb
   undo = reset HEAD~1 --mixed
+  gone = !git fetch -p && git branch -vv | awk '/: gone]/{print $1}' | xargs -r git branch -D
 
 [user]
 	name = alxjrvs
@@ -52,6 +53,7 @@
 [push]
 	autoSetupRemote = true
 	followTags = true
+	useForceIfIncludes = true
 [pull]
 	rebase = true
 [rerere]


### PR DESCRIPTION
## Summary

- Adds a `git gone` alias in `[alias]`: `git fetch -p && git branch -vv | awk '/: gone]/{print $1}' | xargs -r git branch -D`. `fetch.prune` is already enabled elsewhere in this `.gitconfig`, which marks stale remote-tracking branches `[gone]` in `branch -vv` but never deletes the local branches themselves — this closes that loop, which matters for an agent-driven PR workflow that leaves behind a lot of merged/closed local branches.
- Adds `push.useForceIfIncludes = true` to the existing `[push]` section, so `--force-with-lease` is actually safe against a background fetch having moved the remote-tracking ref — relevant given this is a rebase-heavy, agent-driven workflow with frequent force-pushes.

Re-read `.gitconfig` after editing and confirmed valid git-config INI syntax (`git config -f .gitconfig --get alias.gone` / `--get push.useForceIfIncludes` both resolve correctly, no orphaned brackets or malformed sections).

Note: `xargs -r` (used in the `gone` alias, matching the requested command verbatim) is a GNU-ism — worth a quick manual check that it behaves as expected on macOS `xargs` before relying on it day-to-day.

## Test plan

- [ ] `git config -f .gitconfig --get alias.gone` and `--get push.useForceIfIncludes` resolve as expected (done in this session)
- [ ] After merge/link, run `git gone` in a repo with merged/closed branches and confirm it prunes only `[gone]`-marked local branches
- [ ] Confirm `--force-with-lease` behavior is unaffected in normal (non-concurrent-fetch) use

**This PR should NOT be auto-merged — needs manual review**, since it changes global git config that gets symlinked to `~/.gitconfig` on the owner's machine.