### PR TITLE
chore(karabiner): remove duplicate caps-lock-to-control remap

### DIFF
--- a/karabiner/karabiner.json
+++ b/karabiner/karabiner.json
@@ -1,17 +1,6 @@
 {
     "profiles": [
         {
-            "devices": [
-                {
-                    "identifiers": { "is_keyboard": true },
-                    "simple_modifications": [
-                        {
-                            "from": { "key_code": "caps_lock" },
-                            "to": [{ "key_code": "left_control" }]
-                        }
-                    ]
-                }
-            ],
             "name": "Default profile",
             "selected": true,
             "simple_modifications": [


### PR DESCRIPTION
## Summary

`karabiner/karabiner.json` declared the same caps_lock -> left_control remap twice: once inside a device entry matching every keyboard (`identifiers.is_keyboard: true`), and once as the profile-level `simple_modifications` rule. Because the device identifier matches all keyboards, the device-scoped copy was fully subsumed by the profile-level one — they were functionally identical, just declared at two different scopes.

Removed the device-scoped duplicate (and the now-empty `devices` array along with it), keeping the profile-level `simple_modifications` rule, since that's the conventional and most discoverable place in Karabiner-Elements to find/edit a simple single-key remap like this.

Note: the task description referred to the profile-level rule as a "complex_modifications rule," but both occurrences in the actual file are `simple_modifications` — there is no `complex_modifications` block in this file. The structural description (device-scoped vs. profile-level duplication) matches reality; only that label differs.

Validated with `jq empty karabiner/karabiner.json` after editing.

**This PR should NOT be auto-merged and needs manual review** before merging, since it touches a personal input-remapping config file.