### PR TITLE
docs(claude): encode preferred repo merge/branch-protection settings

### DIFF
--- a/dot-claude/CLAUDE.md
+++ b/dot-claude/CLAUDE.md
@@ -27,6 +27,28 @@ Claude Code isolates background/subagent work into git worktrees by default (`wo
 - **Stale/crashed worktrees**: a killed session leaves its worktree `locked` (`.git/worktrees/<name>/locked` names the holding PID) instead of reaped. `git worktree list --porcelain` shows the PID; if it's dead, `git worktree unlock <path> && git worktree remove <path>` reclaims it. Never force-remove a worktree whose lock PID is alive — that's another session's in-flight work.
 - **Completion = commit → push → PR → auto-merge.** Once an agent's work is committed, pushed, and a PR opened, `gh pr merge --auto --squash --delete-branch` is the preferred way to land it — GitHub's own gated queue (waits on required checks, GitHub performs the merge, deletes the branch) rather than a local `git merge`/`git push` into the shared `main` checkout. Confirmed 2026-07-08: alxjrvs wants this to also cover unattended background jobs, not just interactive sessions — but writing that as a blanket standing pre-authorization in this file was blocked twice by the Claude Code auto-mode "instruction poisoning" classifier (chat confirmation doesn't clear that rule by design). So this is **not yet an enforced policy** — it's a documented intent. If you want background jobs to actually auto-merge without asking, the classifier's own guidance is to add an explicit Bash permission rule for `gh pr merge` in `settings.json`/`settings.local.json`, or run `gh pr merge --auto` yourself when a PR is ready. A literal local `git merge`/`git push` onto `main` is still off-limits regardless.
 
+## Repository merge & branch-protection defaults
+
+alxjrvs's standing preference for his personal repos (confirmed 2026-07-08): **squash-only merges, rebase-preferred branch updates, linear history required, CI must be green before merging.** Apply this when setting up a new repo (e.g. via `ignite:kickoff`) or when asked to align an existing one. This is a **per-repo, explicit-confirmation action**, not a standing authorization to change settings unprompted.
+
+- **Squash-only — no merge commits, no rebase-merge**: `gh api -X PATCH repos/<owner>/<repo> -F allow_squash_merge=true -F allow_merge_commit=false -F allow_rebase_merge=false`. This is safe to combine with rebase-*preferred updates* below — they're governed by a different setting (see next bullet), not by `allow_rebase_merge`.
+- **Rebase-preferred branch updates**: enable `allow_update_branch=true` (`-F allow_update_branch=true` on the same PATCH) to surface the "Update branch" button. Which method that button offers — merge-commit vs. rebase — is reported to be gated by the branch's `required_linear_history` protection setting (next bullet) rather than by `allow_rebase_merge`, though behavior here has been inconsistent per GitHub community reports, not GitHub's own docs. `required_linear_history` is worth setting regardless, since it's a standalone stated preference (below) independent of whether it also unlocks the rebase-update button. The REST API has no endpoint to force a rebase update itself — only the web UI and `gh pr update-branch --rebase` can do it.
+- **Linear history + CI green, via classic branch protection** on the default branch — `enforce_admins: true` because "CI needs to be green" was stated as a firm rule, including for alxjrvs's own merges. For a one-off emergency bypass, disable and re-enable it rather than weakening the default: `gh api -X DELETE repos/<owner>/<repo>/branches/main/protection/enforce_admins` (disable), `gh api -X POST repos/<owner>/<repo>/branches/main/protection/enforce_admins` (re-enable):
+  ```
+  gh api -X PUT repos/<owner>/<repo>/branches/main/protection --input - <<'EOF'
+  {
+    "required_status_checks": { "strict": true, "contexts": ["<check-name-1>", "<check-name-2>"] },
+    "enforce_admins": true,
+    "required_pull_request_reviews": null,
+    "restrictions": null,
+    "required_linear_history": true,
+    "allow_force_pushes": false,
+    "allow_deletions": false
+  }
+  EOF
+  ```
+  `contexts` must list the repo's actual CI check names (there's no wildcard) — find them from a recent commit: `gh api repos/<owner>/<repo>/commits/main/check-runs --jq '.check_runs[].name'`. `enforce_admins: false` leaves alxjrvs able to bypass in an emergency; flip to `true` only if asked for stricter enforcement.
+
 ## Agent secret access
 
 The agent resolves 1Password secrets through a **service account**, not your desktop biometric session — so a Claude session (interactive *or* headless/cron) gets its secrets with **no Touch ID prompt** and **no dependency on the 1Password desktop app**. This is the 1Password-recommended automation tier ([secure-ai-access](https://www.1password.dev/get-started/secure-ai-access), [developer-quickstart](https://www.1password.dev/get-started/developer-quickstart)).


### PR DESCRIPTION
## Summary
- Adds a new "Repository merge & branch-protection defaults" section to `dot-claude/CLAUDE.md` encoding alxjrvs's standing repo preference: squash-only merges, rebase-preferred branch updates, required linear history, and CI-green-required (enforced for admins too, since "CI needs to be green" was stated as a firm rule).
- Documents the exact `gh api` calls (repo-level PATCH for merge-strategy flags, branch-protection PUT for linear history + required checks) for future Claude sessions to run on request — new repo setup or aligning an existing repo — not a standing authorization to change settings unprompted, matching the pattern already established for `delete_branch_on_merge`.
- Notes a nuance confirmed via research: the "Update branch" button's rebase option is reported to be gated by `required_linear_history`, not by `allow_rebase_merge` (behavior here has been inconsistent per GitHub community reports, GitHub's own docs don't state it directly) — so `allow_rebase_merge` stays `false` (squash-only) without blocking rebase-style updates.

## Test plan
- [x] Pre-commit/pre-push hooks (gitleaks, no-wip) passed on the doc change
- [ ] No settings applied yet — this PR is docs-only, per the ask ("encode this preference... for future claude sessions")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLxKFEnERvrCELorP9Ypao