### PR TITLE
fix(launchd): absolute log paths so caps→control agent actually runs

### DIFF
--- a/launchd/com.alxjrvs.capslock-control.plist
+++ b/launchd/com.alxjrvs.capslock-control.plist
@@ -18,9 +18,12 @@
 	</array>
 	<key>RunAtLoad</key>
 	<true/>
+	<!-- Absolute paths only: launchd does NOT expand ~ or $HOME in plist values.
+	     A ~-prefixed log path made launchd fail this job with EX_CONFIG (exit 78)
+	     before it could run hidutil, silently breaking the Caps→Control remap. -->
 	<key>StandardOutPath</key>
-	<string>~/Library/Logs/capslock-control.log</string>
+	<string>/tmp/capslock-control.log</string>
 	<key>StandardErrorPath</key>
-	<string>~/Library/Logs/capslock-control.log</string>
+	<string>/tmp/capslock-control.log</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

Caps Lock → Left Control stopped working after #62 replaced Karabiner with a native hidutil `RunAtLoad` LaunchAgent. `boom` linked and loaded the agent correctly, but `launchctl list` showed it exiting **78 (`EX_CONFIG`)** and `hidutil property --get UserKeyMapping` was empty — the remap never applied.

## Root cause

`launchd` does **not** expand `~` (or `$HOME`) in plist path values. The agent's `StandardOutPath`/`StandardErrorPath` were `~/Library/Logs/capslock-control.log`, so launchd failed to open the log path and killed the job with `EX_CONFIG` **before** it could exec `hidutil`. boom was fine — the plist was self-sabotaging.

## Fix

Point both log keys at an absolute, username-agnostic `/tmp/capslock-control.log`, and add a comment documenting the launchd gotcha.

## Verified

Booting the corrected agent:

- `last exit code = 0` (was 78)
- `hidutil property --get UserKeyMapping` → `Src 30064771129` (Caps) → `Dst 30064771296` (Left Control) active
- log written to `/tmp/capslock-control.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ustduvDwio4Y3N829HCCc