### PR TITLE
fix(op-agent): biometric-free provision (load SA token before PAT check)

### DIFF
--- a/hooks/op-agent.sh
+++ b/hooks/op-agent.sh
@@ -113,6 +113,12 @@ cmd_provision() {
       echo "op-agent: SA create failed (needs owner/admin token)"
     fi
   fi
+  # Resolve the PAT via the SA token (from the keychain), NOT desktop auth. Without
+  # this, the bare `op read` below falls back to biometric and re-prompts Touch ID on
+  # EVERY `boom source`. The SA can read the claude-agent vault where the PAT lives, so
+  # this is headless. On a first-ever provision the token was just created above, so
+  # _load_sa picks it up too; only SA *creation* itself needs the one-time biometric.
+  _load_sa
   # The PAT is resolved on demand by `git-credential` (no keychain cache); just
   # confirm the vault item exists so a fresh machine gets a clear setup signal.
   if op read "$PAT_REF" > /dev/null 2>&1; then


### PR DESCRIPTION
## Problem

`boom source sync` prompts for Touch ID every run.

## Root cause

`cmd_provision` in `hooks/op-agent.sh` checks for the PAT with `op read "$PAT_REF"`, but in the steady-state branch (SA token already in the keychain) it printed `"SA token present"` and **never exported the token**. With no `OP_SERVICE_ACCOUNT_TOKEN` in the environment, `op` falls back to desktop biometric → a Touch ID prompt on **every** reconcile. The other verbs (`secret`/`header`/`git-credential`) all call `_load_sa` first; provision was the only one that didn't.

## Fix

Call `_load_sa` before the `op read` PAT check so it resolves through the service account — headless and prompt-free. This is a verbatim port of the fix boom already shipped for its example copy in boom#46; this config-repo hook had drifted from it.

## Verified

`bash -n` clean, `shellcheck -S warning` silent. `_load_sa` now precedes the PAT read in `cmd_provision`. (The Touch ID prompt only manifests in an interactive GUI session; the SA-token path is the documented non-biometric `op` auth mode.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ustduvDwio4Y3N829HCCc