### PR TITLE
docs: point at boom's docs instead of restating its command surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,20 +6,18 @@ This file guides Claude Code (claude.ai/code) when working in this repository.
 
 A macOS **dotfiles repo** that is pure **config for [BoomTube](https://github.com/alxjrvs/boom)** — the small TypeScript dotfiles+workspace engine (the executable is `boom`), compiled to a single binary on `PATH`. This repo is its *first consumer*. There is no engine code here: the whole repo is a `boomfile.toml` (the config), a handful of TypeScript `hooks/`, and the payload (`.zshrc`, `zsh/`, `nvim/`, `dot-claude/`, `Brewfile`, `mise.toml`, …) that boom symlinks into place.
 
-```
-boom source set alxjrvs/dotFiles   # clone + record this repo, then reconcile
-boom source       # symlink/copy/install/run from the boomfile.toml
-boom verify       # check drift (exit 0 ok / 2 warn / 1 fail); --json for a report
-boom repair       # repair drift (incl. reaping orphaned links)
-boom rollback     # undo the last sync (restores backed-up files)
-boom uninstall    # remove every managed link
-```
+boom's command surface is boom's to document, not this repo's — the canonical
+reference is the [boom docs](https://alxjrvs.github.io/boom/), `boom --help`, or
+`boom man`. Don't restate the full command list here; it drifts across boom
+releases. Day-to-day: `boom source` reconciles the machine from `boomfile.toml`
+(symlink/copy/install/run), and `boom verify` checks drift (exit 0 ok / 2 warn /
+1 fail; `--json` for a report).
 
 Fresh machine: `curl -fsSL https://raw.githubusercontent.com/alxjrvs/boom/main/install.sh | sh && boom source set alxjrvs/dotFiles` (installs boom, clones + records this repo, reconciles).
 
 ## The `boomfile.toml`
 
-The config is a typed, validated TOML document; boom parses it once and runs each `[[section]]` under the verb. Within a section, resources run in phase order `link → copy → glob → packages → run → hook`. Schema:
+The config is a typed, validated TOML document; boom parses it once and runs each `[[section]]` under the verb. The authoritative schema lives in the [boom docs](https://alxjrvs.github.io/boom/) (`boom validate` checks a file against it) — the summary below is orientation, not the source of truth. Within a section, resources run in phase order `link → copy → glob → packages → run → hook`. Schema:
 
 - `[[section]]` with `name` (the `--only`/tag) and optional `when = { os, host, profile }` to gate by machine.
 - `link` / `copy` `[{ src, dst, mode? }]` and `glob [{ pattern, into }]` — the symlink/copy contract (`dst` may use `~`).

--- a/README.md
+++ b/README.md
@@ -29,16 +29,14 @@ and reconciles the machine. Preview without touching anything first:
 
 ## Day-to-day
 
-| Command | Job |
-|---------|-----|
-| `boom source` | Idempotent re-sync — symlinks, packages, macOS defaults, hooks. Fast on no-op. |
-| `boom source --upgrade` | Same + brew/mise upgrade. |
-| `boom source --only="zsh fragments"` | Only the named section (e.g. brew/mise packages). |
-| `boom verify` | Read-only drift check, incl. orphaned links. Exit `0` clean / `2` warn / `1` fail. |
-| `boom repair` | Repair drift — relink missing/incorrect, reap orphaned links. |
-| `boom uninstall` | Remove every managed link. |
-| `boom code claude` | Mirror `~/Code` into a flat agent workspace (every repo `@`-taggable in `claude agents`). |
-| `boom mcp add NAME -- SERVER` | Register an MCP server the 1Password-native way. |
+The command surface belongs to boom, not this repo, so it isn't restated here (and
+can't drift out of date). The canonical reference is the [boom docs][boom-docs] —
+or `boom --help` / `boom man` locally. In practice you'll reach for two verbs:
+**`boom source`** re-syncs the machine from `boomfile.toml` after you edit config
+(fast on a no-op; `--only="<section>"` scopes it, `--dry-run` previews); **`boom
+verify`** is the read-only drift check (exit `0` clean / `2` warn / `1` fail).
+
+[boom-docs]: https://alxjrvs.github.io/boom/
 
 ## Making it yours
 
@@ -88,6 +86,7 @@ and 1Password commit signing. In brief:
 
 ## The engine
 
-Anything about source/verify/repair semantics, symlink internals, the manifest, or
-orphan reaping lives in [**boom**](https://github.com/alxjrvs/boom), not here.
-This repo is boom's first consumer — and the reference example of a `boomfile`.
+Anything about reconcile/verify semantics, symlink internals, the manifest, or
+orphan reaping lives in [**boom**](https://github.com/alxjrvs/boom) and its
+[docs][boom-docs], not here. This repo is boom's first consumer — and the
+reference example of a `boomfile`.


### PR DESCRIPTION
boom 0.10.0 reverted `repair` back to `fix` — the second CLI rename in as many releases. Rather than keep chasing boom's evolving command names in duplicated tables (as #72 did), point the docs at boom's own source of truth so they can't drift.

## Changes
- **README "Day-to-day" table** and **CLAUDE.md command block** → a short pointer to the [boom docs](https://alxjrvs.github.io/boom/), `boom --help`, and `boom man`. Kept only the two verbs actually used here (`boom source`, `boom verify`) and the fresh-machine bootstrap.
- **boomfile schema section** → notes the authoritative schema lives in the boom docs (`boom validate` checks against it); the inline summary is orientation, not the source of truth. (The `on = "apply"`→`"sync"` fix in #72 was itself schema drift.)
- de-enumerated the "engine" blurb's verb list.

Net effect: this repo stops tracking boom's CLI surface, so a future rename (fix↔repair, etc.) no longer requires a docs PR here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)