### PR TITLE
boomfile: self-refresh the boom skill on reconcile (stop chasing renamed commands)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,15 @@ This file guides Claude Code (claude.ai/code) when working in this repository.
 
 A macOS **dotfiles repo** that is pure **config for [BoomTube](https://github.com/alxjrvs/boom)** — the small TypeScript dotfiles+workspace engine (the executable is `boom`), compiled to a single binary on `PATH`. This repo is its *first consumer*. There is no engine code here: the whole repo is a `boomfile.toml` (the config), a handful of TypeScript `hooks/`, and the payload (`.zshrc`, `zsh/`, `nvim/`, `dot-claude/`, `Brewfile`, `mise.toml`, …) that boom symlinks into place.
 
-boom's command surface is boom's to document, not this repo's — the canonical
-reference is the [boom docs](https://alxjrvs.github.io/boom/), `boom --help`, or
-`boom man`. Don't restate the full command list here; it drifts across boom
-releases. Day-to-day: `boom source` reconciles the machine from `boomfile.toml`
-(symlink/copy/install/run), and `boom verify` checks drift (exit 0 ok / 2 warn /
-1 fail; `--json` for a report).
+boom's command surface is boom's to document, not this repo's — and boom renames
+verbs across releases (repair↔fix, apply→source), so anything hardcoded here goes
+stale. The always-current agentic reference is the **`boom` skill**, regenerated
+from the installed binary on every `boom source` (a `run` step, `boom skill
+--install`) — so it can't lag a `boom upgrade`. For humans: the [boom
+docs](https://alxjrvs.github.io/boom/), `boom --help`, or `boom man`. Don't
+restate the full command list here. Day-to-day: `boom source` reconciles the
+machine from `boomfile.toml` (symlink/copy/install/run), and `boom verify` checks
+drift (exit 0 ok / 2 warn / 1 fail; `--json` for a report).
 
 Fresh machine: `curl -fsSL https://raw.githubusercontent.com/alxjrvs/boom/main/install.sh | sh && boom source set alxjrvs/dotFiles` (installs boom, clones + records this repo, reconciles).
 

--- a/boomfile.toml
+++ b/boomfile.toml
@@ -144,6 +144,16 @@ pattern = "dot-claude/skills/*"
 into = "~/.claude/skills/"
 
 [[section.run]]
+# Regenerate boom's own agentic reference from the installed binary on every
+# reconcile, so `~/.claude/skills/boom/SKILL.md` never drifts behind a `boom
+# upgrade`. boom renames verbs across releases (repair↔fix, apply→source); a
+# hand-maintained or one-time-snapshot skill goes stale and agents chase the
+# churn. `boom skill --install` writes the current surface — boom's own emitter,
+# no wrapper. This is why the docs here don't restate boom's command list.
+on = "sync"
+cmd = "boom skill --install"
+
+[[section.run]]
 # Claude Code CLI via the official native installer (self-updating); never
 # brew/npm, whose builds do not auto-update. Idempotent — only installs when
 # `claude` is missing; the CLI updates itself thereafter.


### PR DESCRIPTION
The root cause of the repeated "boom renamed a command, update the docs" churn: the `boom` skill at `~/.claude/skills/boom/` was a **one-time snapshot** — it reported v0.7.0 while the installed boom was 0.10.0 — so agents loaded a stale command surface and propagated the wrong names.

## Fix
Add a `run` step to the boomfile's Claude section:
```toml
[[section.run]]
on = "sync"
cmd = "boom skill --install"
```
Every `boom source` now regenerates `~/.claude/skills/boom/SKILL.md` from the installed binary via boom's own emitter (no wrapper). The skill tracks the CLI across `boom upgrade`s, so a future `fix`↔`repair`-style rename updates itself.

**Verified:** running the step took the live skill from `v0.7.0` → `v0.10.0`, and `boom repair` → `boom fix`.

CLAUDE.md now names this self-refreshing skill as the always-current *agentic* reference (docs site / `boom --help` for humans), instead of hardcoding verbs that go stale.

Net: this repo stops tracking boom's CLI entirely — the binary documents itself into the skill on every reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)