### PR TITLE
boomfile: enforce hook +x via link.mode, drop the chmod run step

### DIFF
--- a/boomfile.toml
+++ b/boomfile.toml
@@ -127,6 +127,7 @@ dst = "~/.claude/settings.json"
 [[section.link]]
 src = "dot-claude/hooks/rebase-guard.sh"
 dst = "~/.claude/hooks/rebase-guard.sh"
+mode = "755"
 
 # PreToolUse guard (runs before rebase-guard): blocks `git checkout/switch
 # <default>` from inside a linked worktree, where it fails "'<default>' is already
@@ -134,10 +135,7 @@ dst = "~/.claude/hooks/rebase-guard.sh"
 [[section.link]]
 src = "dot-claude/hooks/worktree-checkout-guard.sh"
 dst = "~/.claude/hooks/worktree-checkout-guard.sh"
-
-[[section.run]]
-on = "sync"
-cmd = "chmod +x ~/.claude/hooks/*.sh"
+mode = "755"
 
 [[section.glob]]
 pattern = "dot-claude/skills/*"


### PR DESCRIPTION
The Claude section linked the two PreToolUse hook scripts, then ran `chmod +x ~/.claude/hooks/*.sh` to make them executable — an imperative step that's really declarative config in disguise.

`link.mode` already enforces a mode on the resolved file (proof: `ssh/config` is `100644` in git yet links at `mode = "600"`). So `mode = "755"` on both hook links does exactly what the chmod did, but declaratively.

- add `mode = "755"` to the `rebase-guard.sh` and `worktree-checkout-guard.sh` links
- delete the `chmod +x` run step

One fewer imperative step, and the executable requirement is now explicit in config rather than implicit in the committed git bit. Part of the "convert settings into simple declarative configs" sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)