### PR TITLE
boom: adopt v0.17.0 [boom] notify (drift desktop-notifications)

### DIFF
--- a/boomfile.toml
+++ b/boomfile.toml
@@ -12,6 +12,9 @@
 [boom]
 skill_on_sync = true
 upgrade_on_sync = "check"
+# Desktop-notify (macOS osascript) when a scheduled `boom verify` finds drift, so the
+# boom-verify launchd timer's signal surfaces instead of dying in its log. (needs boom >= 0.17.0)
+notify = true
 schedule = [{ cmd = "code fetch", every = "15m" }]
 
 [[section]]


### PR DESCRIPTION
## No changes were *required*

Your `boomfile.toml` already validates cleanly against the new boom **v0.17.0** schema (15 sections, `boom doctor --config` → OK) — none of v0.17.0's changes are breaking, and you have no deprecated keys.

## What this adopts (optional)

One opt-in v0.17.0 feature that fits your setup: **`[boom] notify = true`**.

You already run a scheduled `boom verify` (the `boom-verify launchd` section). Today that timer's drift verdict only lands in its log. `notify = true` makes a drift result raise a macOS desktop notification (`osascript`) so you actually *see* when a machine has wandered.

```toml
[boom]
skill_on_sync = true
upgrade_on_sync = "check"
notify = true          # ← added
schedule = [{ cmd = "code fetch", every = "15m" }]
```

## ⚠️ Merge order: upgrade boom first

`notify` is a v0.17.0 key. boom's config schema is `strictObject`, so an **older boom (you're on 0.16.4) rejects the unknown key** and `boom source` would fail. Land this only after `boom upgrade` to ≥ 0.17.0 on every machine that syncs this repo.

dotFiles CI (`taplo --no-schema`) passes regardless — it checks TOML syntax, not the boom schema — so a green check here does **not** mean it's safe to sync on 0.16.x.

## Not adopted (deliberately)

- **`fleet = true`** — records a per-machine summary into the repo for `boom fleet`. Genuinely useful across multiple machines, but it adds a tracked `.boom/machines/<host>.json` + periodic commits, so I left it off pending your call on whether you want that.
- **`secret` resource / `boom.lock` / `use` modules** — larger, opinionated changes to how you handle secrets/packages; not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KP2UMxZkG8kptgVEWk4iP8
