### PR TITLE
hooks: run `biome check` for JS/TS/JSON; swap prettier → biome

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,9 @@
 name: lint
 
-# Mirrors the local lefthook pre-commit gate (shellcheck + shfmt + gitleaks +
-# settings.json validity) on every push to main and every PR. Lint only — never
-# runs `boom apply` or mutates anything. (The engine and its tests live in the
-# boom repo; this repo is just boom's config.)
+# Mirrors the local lefthook pre-commit gate (shellcheck + shfmt + biome +
+# gitleaks + settings.json validity) on every push to main and every PR. Lint
+# only — never runs `boom apply` or mutates anything. (The engine and its tests
+# live in the boom repo; this repo is just boom's config.)
 
 on:
   push:
@@ -25,13 +25,19 @@ jobs:
         with:
           install: false
       - name: Install lint tools
-        run: mise install shellcheck shfmt gitleaks jq taplo
+        run: mise install shellcheck shfmt gitleaks jq taplo biome
 
       # Same file set as lefthook.yml's shell globs, resolved via git.
       - name: shellcheck
         run: shellcheck -x $(git ls-files '*.sh' 'git-template/hooks/*')
       - name: shfmt
         run: shfmt -d -i 2 -ci -sr $(git ls-files '*.sh' 'git-template/hooks/*')
+
+      # JS/TS/JSON lint + format gate (the boom hooks + settings.json). Mirrors
+      # lefthook's biome-check; bare `biome check` uses biome.json and respects
+      # .gitignore, so it never touches node_modules / worktrees.
+      - name: biome
+        run: biome check
 
       # Scan the current tree (not full history) — mirrors the pre-commit secret
       # gate without risking flaky failures on old history.

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true
+  }
+}

--- a/dot-claude/settings.json
+++ b/dot-claude/settings.json
@@ -31,9 +31,7 @@
     "commit": "Co-Authored-By: alxjrvs <alxjrvs@gmail.com>"
   },
   "permissions": {
-    "allow": [
-      "Bash(gh pr merge:*)"
-    ],
+    "allow": ["Bash(gh pr merge:*)"],
     "deny": [
       "Bash(security find-generic-password:*)",
       "Read(~/.ssh/id_*)",

--- a/hooks/claude_statusline.ts
+++ b/hooks/claude_statusline.ts
@@ -1,8 +1,9 @@
 // hook: claude_statusline — clone the statusline repo beside the dotfiles repo and
 // run its installer. Input: with.repo (git url). Ported from claude_statusline.sh.
-import { $ } from "bun";
+
 import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { $ } from "bun";
 
 interface Api {
   with: Record<string, string>;
@@ -39,7 +40,8 @@ export async function sync(api: Api): Promise<void> {
 
 export function verify(api: Api): void {
   const bin = join(api.env.HOME ?? "", ".local", "bin", "claude-statusline");
-  if (existsSync(bin) && (statSync(bin).mode & 0o111) !== 0) api.ok("statusline on PATH");
+  if (existsSync(bin) && (statSync(bin).mode & 0o111) !== 0)
+    api.ok("statusline on PATH");
   else api.warn("statusline missing — boom source --only=claude_statusline");
 }
 

--- a/hooks/git-signing.ts
+++ b/hooks/git-signing.ts
@@ -3,9 +3,16 @@
 // 1Password-agent key named by with.key (default GitHubSSH). gpgSign stays
 // machine-local so a box without 1Password doesn't fail commits. Ported from
 // git-signing.sh.
-import { $ } from "bun";
-import { appendFileSync, chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
+import { $ } from "bun";
 
 interface Api {
   with: Record<string, string>;
@@ -20,7 +27,14 @@ const DOTFILES = join(import.meta.dir, ".."); // hooks/ → repo root (was $BOOM
 const PROG = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign";
 const home = (api: Api): string => api.env.HOME ?? "";
 const sock = (api: Api): string =>
-  join(home(api), "Library", "Group Containers", "2BUA8C4S2C.com.1password", "t", "agent.sock");
+  join(
+    home(api),
+    "Library",
+    "Group Containers",
+    "2BUA8C4S2C.com.1password",
+    "t",
+    "agent.sock",
+  );
 
 // "<type> <data>" of the named signing key from the 1Password agent ("" if unavailable).
 async function pubkey(api: Api, name: string): Promise<string> {
@@ -40,22 +54,32 @@ async function pubkey(api: Api, name: string): Promise<string> {
 export async function sync(api: Api): Promise<void> {
   const name = api.with.key ?? "GitHubSSH";
   if (api.dryRun) {
-    api.note("would converge signing in ~/.gitconfig.local + ~/.ssh/allowed_signers");
+    api.note(
+      "would converge signing in ~/.gitconfig.local + ~/.ssh/allowed_signers",
+    );
     return;
   }
   if (!existsSync(PROG)) {
-    api.warn("op-ssh-sign not found (install 1Password) — skipping signing setup");
+    api.warn(
+      "op-ssh-sign not found (install 1Password) — skipping signing setup",
+    );
     return;
   }
   const pub = await pubkey(api, name);
   if (!pub) {
-    api.warn(`1Password agent not offering "${name}" (running? SSH agent enabled?) — skipping`);
+    api.warn(
+      `1Password agent not offering "${name}" (running? SSH agent enabled?) — skipping`,
+    );
     return;
   }
 
   // Machine-local git overrides: sign with the 1Password key via op-ssh-sign.
   const cfg = join(home(api), ".gitconfig.local");
-  if (!existsSync(cfg)) writeFileSync(cfg, "# Machine-local git overrides — NOT in dotfiles. Written by boom.\n");
+  if (!existsSync(cfg))
+    writeFileSync(
+      cfg,
+      "# Machine-local git overrides — NOT in dotfiles. Written by boom.\n",
+    );
   await $`git config --file ${cfg} commit.gpgSign true`.nothrow().quiet();
   await $`git config --file ${cfg} tag.gpgSign true`.nothrow().quiet();
   await $`git config --file ${cfg} gpg.ssh.program ${PROG}`.nothrow().quiet();
@@ -83,7 +107,9 @@ export async function sync(api: Api): Promise<void> {
   ).trim();
   if (email) {
     const line = `${email} ${pub}`;
-    const have = existsSync(allowed) && readFileSync(allowed, "utf8").split("\n").includes(line);
+    const have =
+      existsSync(allowed) &&
+      readFileSync(allowed, "utf8").split("\n").includes(line);
     if (!have) {
       appendFileSync(allowed, `${line}\n`);
       api.ok("allowed_signers updated");
@@ -95,8 +121,14 @@ export async function sync(api: Api): Promise<void> {
 
 export function verify(api: Api): void {
   const cfg = join(home(api), ".gitconfig.local");
-  const r = Bun.spawnSync(["git", "config", "--file", cfg, "commit.gpgSign"], { stdout: "pipe", stderr: "ignore" });
-  if (r.exitCode === 0 && new TextDecoder().decode(r.stdout).trim() === "true") {
+  const r = Bun.spawnSync(["git", "config", "--file", cfg, "commit.gpgSign"], {
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (
+    r.exitCode === 0 &&
+    new TextDecoder().decode(r.stdout).trim() === "true"
+  ) {
     api.ok("commit signing enabled (~/.gitconfig.local)");
   } else {
     api.warn("signing not configured — run: boom source --only=git-signing");

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,6 @@
 # Lefthook config for this repo (a boom config / dotfiles repo).
 #
-# pre-commit: lint staged shell + guard secrets and settings.json.
+# pre-commit: lint staged shell + JS/TS/JSON, guard secrets and settings.json.
 #
 # no_auto_install: boom owns hook installation (the `lefthook` hook runs
 # `lefthook install` on apply). After a lefthook.yml change, re-run
@@ -20,6 +20,13 @@ pre-commit:
       glob: "{*.sh,git-template/hooks/*}"
       # -d prints a unified diff and exits nonzero — won't auto-rewrite on commit
       run: shfmt -d -i 2 -ci -sr {staged_files}
+    biome-check:
+      # JS/TS/JSON lint + format gate (the only JS/TS here is the boom hooks;
+      # JSON includes dot-claude/settings.json). `check` reports without
+      # rewriting — like shfmt-check, it won't auto-fix on commit; run
+      # `biome check --write` to fix. Config: biome.json (2-space, gitignore-aware).
+      glob: "{*.ts,*.tsx,*.js,*.jsx,*.json,*.jsonc}"
+      run: biome check {staged_files}
     gitleaks:
       run: gitleaks protect --staged --redact -v --no-banner
     settings-json-validity:

--- a/mise.toml
+++ b/mise.toml
@@ -45,13 +45,15 @@ eza = "latest"
 # ── Linters / formatters ─────────────────────────────────────────────
 shfmt = "latest"
 shellcheck = "latest"
+biome = "latest"                          # JS/TS/JSON linter+formatter — `biome check`
+                                          # (lefthook + CI + nvim format-on-save); registry
+                                          # short-name → aqua:biomejs/biome
 
 # ── Neovim language servers (nvim/init.lua wires these in) ────────────
 # rust-analyzer is not global — it comes with a per-project `rust` toolchain,
 # and nvim/init.lua picks it up automatically when present.
 "npm:bash-language-server" = "latest"
 "npm:typescript-language-server" = "latest"
-"npm:prettier" = "latest"                 # JS/TS/JSX/TSX formatter (nvim/init.lua format-on-save)
 "aqua:artempyanykh/marksman" = "latest"   # markdown LSP
 taplo = "latest"                          # TOML LSP + formatter (`taplo lsp stdio`); registry alias → aqua:tamasfe/taplo (no -cli suffix)
 

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -94,10 +94,13 @@ end
 local formatters = {
   sh = { "shfmt", "-i", "2", "-ci", "-sr" },
   bash = { "shfmt", "-i", "2", "-ci", "-sr" },
-  typescript = { "prettier", "--parser", "typescript" },
-  typescriptreact = { "prettier", "--parser", "typescript" },
-  javascript = { "prettier", "--parser", "babel" },
-  javascriptreact = { "prettier", "--parser", "babel" },
+  -- biome check --write applies formatting + safe lint fixes (incl. import
+  -- sorting) and prints the result to stdout; --stdin-file-path's extension
+  -- tells biome the language. Mirrors the `biome check` lefthook/CI gate.
+  typescript = { "biome", "check", "--write", "--stdin-file-path=stdin.ts" },
+  typescriptreact = { "biome", "check", "--write", "--stdin-file-path=stdin.tsx" },
+  javascript = { "biome", "check", "--write", "--stdin-file-path=stdin.js" },
+  javascriptreact = { "biome", "check", "--write", "--stdin-file-path=stdin.jsx" },
   toml = { "taplo", "fmt", "-" },
 }
 


### PR DESCRIPTION
## What

Adopt **biome** as the single JS/TS/JSON linter+formatter, replacing prettier and adding lint coverage the boom hooks never had.

The only JS/TS in this repo is `hooks/git-signing.ts` and `hooks/claude_statusline.ts` — previously **unlinted** (prettier was wired only for nvim format-on-save). Now `biome check` gates them (and `dot-claude/settings.json`) in both the lefthook pre-commit and the CI lint workflow.

## Changes

- **`biome.json`** (new) — 2-space indent, gitignore-aware (`vcs.useIgnoreFile`), recommended lint rules.
- **`lefthook.yml`** — add a `biome-check` pre-commit command over `{*.ts,*.tsx,*.js,*.jsx,*.json,*.jsonc}`. `check` reports without rewriting (like `shfmt -d`); use `biome check --write` to fix.
- **`.github/workflows/lint.yml`** — install `biome` via mise + add a `biome check` step. Mirrors the local gate.
- **`mise.toml`** — replace `npm:prettier` with `biome` (registry short-name → `aqua:biomejs/biome`).
- **`nvim/init.lua`** — format-on-save for TS/JS/TSX/JSX now runs `biome check --write --stdin-file-path=…` instead of prettier.
- **`hooks/*.ts` + `dot-claude/settings.json`** — normalized to biome's style so the new gate passes on a clean tree.

Shell (`shellcheck`/`shfmt`), TOML (`taplo`), and secret (`gitleaks`) gates are untouched — biome can't cover those.

## Verification

- `biome check` passes clean project-wide.
- `lefthook run pre-commit` (with biome installed via mise) — all commands ✔️, biome-check included.
- `settings.json` still passes jq validity + the four content guardrails after reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01An96drykz3mNvo54UvHQkG