### PR TITLE
skill(agent-friendly-repo): package merge-settings + ruleset playbook (#58)

### DIFF
--- a/dot-claude/CLAUDE.md
+++ b/dot-claude/CLAUDE.md
@@ -40,23 +40,25 @@ Claude Code isolates background/subagent work into git worktrees by default (`wo
 
 alxjrvs's standing preference for his personal repos (confirmed 2026-07-08): **squash-only merges, rebase-preferred branch updates, linear history required, CI must be green before merging.** Apply this when setting up a new repo (e.g. via `ignite:kickoff`) or when asked to align an existing one. This is a **per-repo, explicit-confirmation action**, not a standing authorization to change settings unprompted.
 
+**The executable version of this section is the `agent-friendly-repo` skill** (`dot-claude/skills/agent-friendly-repo/`) — it reads current state, diffs against the checklist below, asks, then applies the merge settings + ruleset (and optionally a merge queue). Use the skill for the full flow; the recipes below are the reference it encodes.
+
 - **Squash-only — no merge commits, no rebase-merge**: `gh api -X PATCH repos/<owner>/<repo> -F allow_squash_merge=true -F allow_merge_commit=false -F allow_rebase_merge=false`. This is safe to combine with rebase-*preferred updates* below — they're governed by a different setting (see next bullet), not by `allow_rebase_merge`.
 - **Rebase-preferred branch updates**: enable `allow_update_branch=true` (`-F allow_update_branch=true` on the same PATCH) to surface the "Update branch" button. Which method that button offers — merge-commit vs. rebase — is reported to be gated by the branch's `required_linear_history` protection setting (next bullet) rather than by `allow_rebase_merge`, though behavior here has been inconsistent per GitHub community reports, not GitHub's own docs. `required_linear_history` is worth setting regardless, since it's a standalone stated preference (below) independent of whether it also unlocks the rebase-update button. The REST API has no endpoint to force a rebase update itself — only the web UI and `gh pr update-branch --rebase` can do it.
-- **Linear history + CI green, via classic branch protection** on the default branch — `enforce_admins: true` because "CI needs to be green" was stated as a firm rule, including for alxjrvs's own merges. For a one-off emergency bypass, disable and re-enable it rather than weakening the default: `gh api -X DELETE repos/<owner>/<repo>/branches/main/protection/enforce_admins` (disable), `gh api -X POST repos/<owner>/<repo>/branches/main/protection/enforce_admins` (re-enable):
-  ```
-  gh api -X PUT repos/<owner>/<repo>/branches/main/protection --input - <<'EOF'
-  {
-    "required_status_checks": { "strict": true, "contexts": ["<check-name-1>", "<check-name-2>"] },
-    "enforce_admins": true,
-    "required_pull_request_reviews": null,
-    "restrictions": null,
-    "required_linear_history": true,
-    "allow_force_pushes": false,
-    "allow_deletions": false
-  }
-  EOF
-  ```
-  `contexts` must list the repo's actual CI check names (there's no wildcard) — find them from a recent commit: `gh api repos/<owner>/<repo>/commits/main/check-runs --jq '.check_runs[].name'`. `enforce_admins: false` leaves alxjrvs able to bypass in an emergency; flip to `true` only if asked for stricter enforcement.
+- **Linear history + CI green, via a ruleset (preferred) — one mechanism, not classic + ruleset both.** GitHub takes the *union* of classic branch protection and rulesets, so having both is a footgun (edit one, the other silently still applies). Make the **ruleset** the single source of truth and delete the redundant classic protection (`gh api -X DELETE repos/<owner>/<repo>/branches/<branch>/protection`) once the ruleset supersets it. Ruleset rules for the default branch: `required_linear_history`, `non_fast_forward`, `deletion`; `required_status_checks` pointing at a **single aggregate gate job** (an `if: always()` job that `needs:` every other job — not each individual check, which strands required checks in "pending" on path-filtered PRs); **no required human PR reviews** (a required review blocks agent auto-merge forever — agents can't approve their own PRs); and `bypass_actors: []` so nobody bypasses, incl. admins → "CI green for everyone" (agents don't need bypass; `--auto` just waits for green). For a one-off emergency, disable+re-enable the ruleset rather than adding a standing bypass. Real check names have no wildcard — find them via `gh api repos/<owner>/<repo>/commits/<branch>/check-runs --jq '.check_runs[].name'`. The `agent-friendly-repo` skill applies all of this (plus the optional merge queue and its `merge_group:`-trigger sequencing hazard).
+  - **Classic protection (legacy fallback only)** — if a repo can't use rulesets, the equivalent classic form is `enforce_admins: true` (CI green for everyone) + a one-off emergency bypass via `gh api -X DELETE .../branches/main/protection/enforce_admins` (disable) / `-X POST` (re-enable):
+    ```
+    gh api -X PUT repos/<owner>/<repo>/branches/main/protection --input - <<'EOF'
+    {
+      "required_status_checks": { "strict": true, "contexts": ["<aggregate-check>"] },
+      "enforce_admins": true,
+      "required_pull_request_reviews": null,
+      "restrictions": null,
+      "required_linear_history": true,
+      "allow_force_pushes": false,
+      "allow_deletions": false
+    }
+    EOF
+    ```
 
 ## Agent secret access
 

--- a/dot-claude/skills/agent-friendly-repo/SKILL.md
+++ b/dot-claude/skills/agent-friendly-repo/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: agent-friendly-repo
+description: Make a GitHub repo agent-friendly for automated PR → auto-merge — squash-only merge settings, a single ruleset (linear history, non-fast-forward, one aggregate status check, no required human review, no bypass), and optionally a merge queue. Use when the user says "make this repo agent-friendly", "set up auto-merge", "align merge settings + branch protection", "add a merge queue", or bootstraps a repo and wants the agent completion path (`gh pr merge --auto`) to work. The executable version of the "Repository merge & branch-protection defaults" + "Agent worktree & merge workflow" sections in ~/.claude/CLAUDE.md.
+---
+
+# agent-friendly-repo
+
+Turn a GitHub repo into one where the agent completion path — commit → push → PR → `gh pr merge --auto --squash` — actually lands, with **CI green for everyone** and **no human review gate** (agents can't approve their own PRs). Encodes the playbook worked out for `SalvageUnion-io/SU-SRD` (PR #393 + ruleset #9182849).
+
+This mutates **outward-facing, shared-repo config**. Always read current state, print a proposed-changes diff, and **ask before mutating** — even under auto mode. Do the read + report unprompted; gate the writes.
+
+## The checklist (what "agent-friendly" enforces)
+
+**Repo merge settings** — `gh api repos/{o}/{r}`:
+- `allow_squash_merge=true`, `allow_merge_commit=false`, `allow_rebase_merge=false` — squash-only.
+- `allow_auto_merge=true` — **required** for `gh pr merge --auto`, the agent completion path. Without it, `--auto` errors.
+- `delete_branch_on_merge=true` — GitHub deletes the remote branch server-side on merge, so agent worktree branches don't pile up (this is also the native fix for the #53 `--delete-branch` worktree-`main` collision — see CLAUDE.md).
+- `allow_update_branch=true` — surfaces the "Update branch" button.
+- `squash_merge_commit_title=PR_TITLE`, `squash_merge_commit_message=BLANK` (or `COMMIT_MESSAGES`) — clean squash subjects.
+
+**Branch protection — ONE mechanism: a ruleset. Not classic + ruleset both.**
+GitHub takes the **union** of classic protection and rulesets — a footgun, because editing one silently won't reflect in the other. Make the ruleset the single source of truth and **delete the redundant classic protection** once the ruleset supersets it.
+
+Ruleset rules for the default branch:
+- `required_linear_history`, `non_fast_forward`, `deletion` — block force-push and branch deletion, keep history linear.
+- `required_status_checks` → a **single aggregate gate job** (e.g. `quality-checks`), not every individual job. An aggregate `if: always()` job that `needs:` every other job and fails if any *actually failed* (path-filtered "skipped" jobs are fine) avoids "required check stuck pending" when per-area jobs are path-filtered out of a given PR.
+- **No required human PR reviews.** A required review blocks agent auto-merge forever — agents can't approve their own PRs. `--auto` waiting on green CI is the gate, not a human.
+- `bypass_actors: []` — nobody bypasses, incl. admins → "CI green for everyone" (the standing preference). Agents don't need bypass; `--auto` just waits for green.
+
+**Merge queue — the throughput unlock for parallel agents (optional, gated on CI support).**
+`strict` required-status-checks (require-branch-up-to-date-before-merge) *serializes* parallel PRs: each merge marks every other open PR out-of-date → forced rebase + full CI re-run per PR. A **merge queue** removes that churn while preserving "tested against latest main" (it tests each PR against the merged result). See the sequencing hazard below — enabling it before CI handles `merge_group` hangs every PR.
+
+## Procedure
+
+1. **Resolve the repo + default branch.**
+   ```
+   o=$(gh repo view --json owner --jq .owner.login); r=$(gh repo view --json name --jq .name)
+   def=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+   ```
+
+2. **Read current state** (all reads, no writes):
+   ```
+   gh api repos/$o/$r --jq '{allow_squash_merge,allow_merge_commit,allow_rebase_merge,allow_auto_merge,delete_branch_on_merge,allow_update_branch,squash_merge_commit_title,squash_merge_commit_message}'
+   gh api repos/$o/$r/branches/$def/protection 2>/dev/null || echo "no classic protection"
+   gh api repos/$o/$r/rulesets --jq '.[] | {id,name,target,enforcement}'
+   # then for each ruleset id: gh api repos/$o/$r/rulesets/{id}
+   gh api repos/$o/$r/commits/$def/check-runs --jq '.check_runs[].name' | sort -u   # real check names — no wildcard, must be exact
+   ```
+
+3. **Detect the aggregate gate job.** From the check-run names and the CI workflow(s) under `.github/workflows/`, find a single job that `needs:` the others with `if: always()`. If none exists, **recommend/scaffold one** — do NOT require every individual check (that leaves required checks stuck pending on path-filtered PRs). Scaffold shape:
+   ```yaml
+   quality-checks:
+     if: always()
+     needs: [lint, test, typecheck]      # every other job
+     runs-on: ubuntu-latest
+     steps:
+       - name: Fail if any dependency failed
+         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+         run: exit 1
+   ```
+
+4. **Diff against the checklist and print a proposed-changes report.** Group by: repo merge settings, ruleset (create/update/what rules), classic protection to delete, aggregate-gate action, merge-queue eligibility. Then **ask for confirmation** before any write.
+
+5. **Apply merge settings** (one PATCH):
+   ```
+   gh api -X PATCH repos/$o/$r \
+     -F allow_squash_merge=true -F allow_merge_commit=false -F allow_rebase_merge=false \
+     -F allow_auto_merge=true -F delete_branch_on_merge=true -F allow_update_branch=true \
+     -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=BLANK
+   ```
+
+6. **Create/update the ruleset** as the single source of truth. `~ref` for the default branch is `~DEFAULT_BRANCH`. Replace `<aggregate-check>` with the real name from step 3.
+   ```
+   gh api -X POST repos/$o/$r/rulesets --input - <<'EOF'
+   {
+     "name": "default-branch-protection",
+     "target": "branch",
+     "enforcement": "active",
+     "bypass_actors": [],
+     "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+     "rules": [
+       { "type": "deletion" },
+       { "type": "non_fast_forward" },
+       { "type": "required_linear_history" },
+       { "type": "required_status_checks",
+         "parameters": {
+           "strict_required_status_checks_policy": true,
+           "required_status_checks": [ { "context": "<aggregate-check>" } ]
+         } }
+     ]
+   }
+   EOF
+   ```
+   To update an existing ruleset instead, `gh api -X PUT repos/$o/$r/rulesets/{id} --input -` with the same body.
+
+7. **Delete the redundant classic protection** — only *after* confirming the ruleset supersets it:
+   ```
+   gh api -X DELETE repos/$o/$r/branches/$def/protection
+   ```
+
+8. **Merge queue (optional, only if the user wants it).** Follow the sequencing hazard below.
+
+9. **Report** the final state: merge settings, ruleset id + rules, whether classic was removed, aggregate-gate action taken, queue enabled or deferred (and why).
+
+## Critical sequencing hazard — merge queue
+
+Enabling the queue before CI reports on the queue's temp branches **hangs every PR forever**. Enforce this order:
+
+1. **Land the CI `merge_group:` trigger on `main` FIRST**, via a normal PR under current rules. Add `merge_group:` to the workflow's `on:` so the aggregate check reports on the queue's temp branches. Also force-enable path-filtered jobs on `merge_group` (they have no diff base there — the queue is the final gate before main), e.g. a `changes` job that outputs "all areas changed" when `github.event_name == 'merge_group'`.
+2. **Only after that's merged to `main`:** add the `merge_queue` rule to the ruleset **and** set `strict_required_status_checks_policy: false` (the queue supersedes strict; GitHub disallows strict alongside a queue). Add `{ "type": "merge_queue", "parameters": { ... } }` to the ruleset `rules` and flip the strict flag in the `required_status_checks` rule.
+
+Then agents complete with `gh pr merge --auto --squash`, which adds the PR to the queue; the queue tests it against the merged result and lands it when green.
+
+## Guardrails
+
+- **Ask before every mutation.** Reads and the diff report are unprompted; writes are gated. This is shared-repo config.
+- **Never require a human review** and never leave `bypass_actors` non-empty for "convenience" — both defeat the agent path. If the user *wants* human review on a repo, that repo isn't a candidate for unattended auto-merge; say so rather than half-configuring it.
+- **`enforce_admins`/no-bypass = CI green for everyone, including alxjrvs.** For a genuine one-off emergency, disable+re-enable rather than weakening the default (delete the ruleset temporarily, or from a plain terminal). Don't add a standing bypass.
+- **Aggregate gate, not per-check requirements.** Requiring individual path-filtered jobs strands required checks in "pending". If you can't find/scaffold an aggregate job, stop and surface that — don't require the individual jobs as a fallback.
+- **Merge queue is opt-in and CI-gated.** Never add the `merge_queue` rule before the `merge_group:` trigger is on `main`. If CI has no `merge_group:` trigger, do the CI PR first (or defer the queue) — never enable it speculatively.
+- **Reference target:** SU-SRD PR #393 (the `merge_group` CI trigger + `changes` path-filter handling) and SU-SRD ruleset #9182849 are a known-good "after" state.


### PR DESCRIPTION
## What

Resolves the two open issues.

### #58 — `agent-friendly-repo` skill (Closes #58)
New skill `dot-claude/skills/agent-friendly-repo/` — the *executable* version of the "Repository merge & branch-protection defaults" + "Agent worktree & merge workflow" sections in `CLAUDE.md`. It:

- Reads a repo's merge settings, classic protection, rulesets, and **real check names** (no wildcard).
- Diffs against the agent-friendly checklist, prints a proposed-changes report, and **asks before mutating** (shared-repo config).
- Applies squash-only merge settings (`allow_auto_merge`, `delete_branch_on_merge`, `allow_update_branch`, PR-title squash) + a **single ruleset** as the source of truth (linear history, non-fast-forward, deletion block, one **aggregate** status check, **no required human review**, `bypass_actors: []`), then deletes redundant classic protection.
- Detects/scaffolds the aggregate `if: always()` gate job (avoids "required check stuck pending" on path-filtered PRs).
- Optional merge queue with the **`merge_group:`-trigger sequencing hazard** enforced (land the CI trigger on `main` first, *then* enable the queue + flip `strict` off).

Also updates the `CLAUDE.md` branch-protection recipe to target **rulesets** (single source of truth) with classic protection kept as a documented legacy fallback, and points at the skill.

The `dot-claude/skills/*` boomfile glob links the new skill into `~/.claude/skills/` on next `boom source`.

### #80 — non-JS pre-commit failure
No code change here. Investigated: this repo's `git-template/hooks/pre-commit` is already language-agnostic (gitleaks + `.mcp.json`/`.env` secret checks — no `package.json`, no `bun run`, confirmed via git history). The failing hook in #80 used `SKIP_SIMPLE_GIT_HOOKS=1` — the bypass env var of the **`simple-git-hooks`** npm package (a per-project JS tool scaffolded outside dotFiles), not boom's template. Closing #80 with that explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKvq5nMT8cdpH8Ezo8tv81