### PR TITLE
feat(gh): adopt stacked PRs via the official github/gh-stack extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ Small steps (`chmod 700 ~/.ssh`, `lefthook install`) are inline `run` (`on = "ap
 
 `Brewfile` holds **only** `mise` (bootstrap), casks (GUI apps, fonts), and system libs with no mise equivalent. `mise.toml` holds all language toolchains AND dev CLIs (`jq`, `shellcheck`, `shfmt`). If you're about to add a CLI to `Brewfile`, stop — it goes in `mise.toml` unless it's `mise` itself or a cask.
 
+**`gh` extensions are the one exception to both** — they aren't packages either manager knows about, and boom has no `gh` manager, so the `gh extensions` section carries install-if-absent `run` steps (today: the official `github/gh-stack`, for stacked PRs). That section **must stay after `packages`**: `gh` comes from mise and sections run in file order, so a fresh machine has no `gh` on PATH before it.
+
 ## Terminal: Ghostty (sole terminal)
 
 Ghostty is the only terminal (`TERMINAL=ghostty`, `ghostty/config`) — one symlinked file for rendering + keybinds/visor. Parallel Claude Code sessions run through `claude agents` mode directly (standalone Ghostty, no multiplexer: `claude agents` already does parallel dispatch, session persistence, and git-worktree isolation, so a multiplexing terminal is redundant). `boom code` mirrors `~/Code` into workspaces: `boom code init [DIR]` records the dir, `boom code claude` symlinks every repo into one flat dir and opens `claude agents` there so each repo is `@`-taggable for dispatch. (cmux, a libghostty agent multiplexer, was removed for this reason; `boom code cmux` — the per-repo workspace variant — is an unused engine feature.)

--- a/boomfile.toml
+++ b/boomfile.toml
@@ -296,9 +296,17 @@ name = "gh extensions"
 # file order, so a fresh machine has no `gh` on PATH until packages has run.
 #
 # `gh` has no declarative manifest and boom has no `gh` pkg manager (brew/mise/cargo/npm/
-# pipx/gem/apt/dnf/flatpak only), so this is imperative by necessity: install-if-absent, then
-# let gh's own daily extension auto-update keep it current. Not `|| true` — an extension the
-# stacked-PR workflow depends on should fail loudly, not silently go missing.
+# pipx/gem/apt/dnf/flatpak only), so this is imperative by necessity: install-if-absent. Not
+# `|| true` — an extension the stacked-PR workflow depends on should fail loudly, not silently
+# go missing.
+#
+# Deliberately install-only, NOT upgrade. gh does not auto-update extensions: it "will check
+# for new versions once every 24 hours and display an upgrade notice" when the extension runs
+# — a notice, not an install. So this pins nothing and refreshes nothing; `gh stack` stays on
+# whatever version first landed until someone runs `gh extension upgrade gh-stack`. That is a
+# live trap for a v0.1.0 preview tool, and the daily notice is the only thing that surfaces it.
+# Revisit (add an upgrade step, or `boom lock`-style pinning) if the version drifts far enough
+# to bite; don't assume this section keeps it current, because it doesn't.
 #
 # github/gh-stack is the OFFICIAL GitHub extension (public preview since 2026-07-30), which
 # matters because `gh ext search stack` returns four same-named community forks

--- a/boomfile.toml
+++ b/boomfile.toml
@@ -290,6 +290,30 @@ pkg = [
 ]
 
 [[section]]
+name = "gh extensions"
+
+# MUST stay after the `packages` section — `gh` itself comes from mise, and sections run in
+# file order, so a fresh machine has no `gh` on PATH until packages has run.
+#
+# `gh` has no declarative manifest and boom has no `gh` pkg manager (brew/mise/cargo/npm/
+# pipx/gem/apt/dnf/flatpak only), so this is imperative by necessity: install-if-absent, then
+# let gh's own daily extension auto-update keep it current. Not `|| true` — an extension the
+# stacked-PR workflow depends on should fail loudly, not silently go missing.
+#
+# github/gh-stack is the OFFICIAL GitHub extension (public preview since 2026-07-30), which
+# matters because `gh ext search stack` returns four same-named community forks
+# (boneskull/, VladimirAnaniev/, ThePlenkov/gh-stackx, 134130/gh-domino). The `github/` owner
+# in the grep is load-bearing: it is what distinguishes the real one from a fork.
+#
+# Why it earns a place: stacked PRs are the standing preference for agent work (see
+# dot-claude/CLAUDE.md). Each layer is a small reviewable PR, and `gh stack` owns the
+# cascading rebase across N branches that otherwise has to be hand-driven — which is exactly
+# the plumbing the `rebase-prs` skill was written to paper over.
+[[section.run]]
+on = "sync"
+cmd = "gh extension list | grep -q 'github/gh-stack' || gh extension install github/gh-stack"
+
+[[section]]
 name = "macOS defaults"
 
 [[section.osx_default]]

--- a/dot-claude/CLAUDE.md
+++ b/dot-claude/CLAUDE.md
@@ -150,6 +150,22 @@ Claude Code isolates background/subagent work into git worktrees by default
 overridden). Each agent gets `.claude/worktrees/<name>` on a **freshly created branch** off
 `origin/<default-branch>`.
 
+- **Prefer a stack of small PRs over one large one**, via the **official** `github/gh-stack`
+  extension (`gh stack`, public preview since 2026-07-30) — installed by the dotFiles boomfile's
+  `gh extensions` section, never a same-named community fork. Reach for it when a change is
+  bigger than one reviewable PR: `gh stack init` → `gh stack add` per layer → `gh stack submit`
+  (one PR per branch, each based on the one below) → `gh stack sync` after a layer lands. It owns
+  the cascading rebase across the whole stack, which is the part that is miserable by hand.
+  - `gh stack submit`/`push`/`sync` are **not** matched by the rebase-guard (which tokenizes for
+    `git push` / `gh pr create` specifically), so the guard is silent on them. That is not
+    permission to publish a stale stack — `gh stack sync` (fetch + cascading rebase + push) is
+    the stack-shaped version of the rebase-before-push rule, so run it first.
+  - `gh stack merge` merges every PR up to the chosen one all-or-nothing, and **cannot bypass**
+    merge requirements — so it needs `required_linear_history` and empty `bypass_actors`, which
+    the `agent-friendly-repo` checklist already sets. Behind a merge queue the stack is *queued*
+    instead, may land in separate groups, and merge-method flags are ignored.
+  - Stack state lives in `.git/gh-stack` (untracked, per-clone), so a fresh agent worktree does
+    not inherit one — `gh stack checkout <stack#|pr#|url|branch>` re-attaches.
 - **Rebase on the target before pushing.** Before the first `git push` / `gh pr create`:
   `git fetch origin && git rebase origin/<default>` (resolve conflicts; re-push with
   `--force-with-lease` if already pushed). `origin/HEAD` moves while an agent works, so even a
@@ -195,7 +211,8 @@ overridden). Each agent gets `.claude/worktrees/<name>` on a **freshly created b
 ## Repository merge & branch-protection defaults
 
 Standing preference for personal repos: **squash-only merges, rebase-preferred branch updates,
-linear history required, CI green before merging.** Apply when setting up a new repo (e.g. via
+linear history required, CI green before merging, and stacked PRs (`gh stack`) for anything
+bigger than one reviewable change.** Apply when setting up a new repo (e.g. via
 `ignite:kickoff`) or when asked to align an existing one. This is a **per-repo,
 explicit-confirmation action**, not standing authorization to change settings unprompted.
 

--- a/dot-claude/DECISIONS.md
+++ b/dot-claude/DECISIONS.md
@@ -255,6 +255,16 @@ itself comes from mise, sections run in file order, and a fresh machine has no `
 packages has run. The grep matches `github/gh-stack` including the owner, because `gh ext search
 stack` returns four same-named community extensions and only one of them is GitHub's.
 
+It is install-only, and **that is a weaker guarantee than the Claude CLI step it mirrors.** The
+Claude CLI genuinely self-updates after install; `gh` extensions do not — gh "will check for new
+versions once every 24 hours and display an upgrade notice", which is a *notice*, not an install.
+So `gh stack` stays on whatever version first landed until someone runs `gh extension upgrade`.
+For a v0.1.0 public-preview tool that is a real trap, and the daily notice is the only thing that
+surfaces it. An upgrade step was not added because "install this extension" was the ask and a
+network call on every `boom source` is not free; revisit if the version actually drifts far enough
+to bite. The failure mode is documented rather than fixed, deliberately — but it is documented,
+because the first draft of this section wrongly claimed gh auto-updates extensions.
+
 Two things fell out of reading the extension's actual contract rather than assuming:
 
 - **The existing checklist was already a precondition, not merely compatible.** `gh stack modify`

--- a/dot-claude/DECISIONS.md
+++ b/dot-claude/DECISIONS.md
@@ -237,6 +237,47 @@ uncloseable. This recurs after *every* squash-merge; it is a Claude Code limitat
 `commit-commands:clean_gone` does not catch it either — the `worktree-*`/`agent-*` branches have no
 upstream, so there is no `[gone]` signal.
 
+### Stacked PRs adopted via `github/gh-stack` (2026-07-31)
+
+GitHub put stacked PRs into public preview on 2026-07-30 with a first-party CLI extension. That is
+what changed the answer: stacking was always the right shape for agent output — many small
+reviewable layers instead of one 40-file PR — but every previous implementation was a third-party
+tool (Graphite, `git-branchless`, four community `gh-stack` forks) carrying its own metadata model,
+its own hosted service, or both. **Native over special** ruled all of them out. A GitHub-shipped
+extension that stores its state in `.git/gh-stack` and drives the stock PR API is the stock
+behavior, so the principle now argues *for* adoption rather than against it.
+
+It is installed through the boomfile rather than by hand because a workflow preference nobody's
+machine can execute is just prose. `gh` has no declarative manifest and boom has no `gh` package
+manager, so the `gh extensions` section is an install-if-absent `run` step — the same shape as the
+Claude CLI install, and for the same reason. It **must** sit after the `packages` section: `gh`
+itself comes from mise, sections run in file order, and a fresh machine has no `gh` on PATH until
+packages has run. The grep matches `github/gh-stack` including the owner, because `gh ext search
+stack` returns four same-named community extensions and only one of them is GitHub's.
+
+Two things fell out of reading the extension's actual contract rather than assuming:
+
+- **The existing checklist was already a precondition, not merely compatible.** `gh stack modify`
+  refuses a history with merge commits or diverged branches, and `gh stack merge` states outright
+  that bypassing merge requirements is *not supported* for stack merges. So `required_linear_history`
+  and `bypass_actors: []` — already in `agent-friendly-repo` on other grounds — are exactly what
+  stacks need. A repo whose agent path leans on a bypass actor cannot use stacks at all.
+- **The rebase-guard does not see `gh stack`.** It tokenizes for `git push` / `gh pr create`
+  specifically, so `gh stack submit`/`push`/`sync` sail past it. That is a gap in coverage, not a
+  blessing, and it is deliberately *not* fixed by widening the guard: `gh stack sync` already does
+  fetch + cascading rebase + push, so the correct behavior is the rule the guard would have
+  enforced. Widening the guard to deny `gh stack submit` would mean re-deriving stack-aware
+  behind-ness for N branches — a lot of security-relevant shell to duplicate what the tool does
+  natively. The rule lives in `CLAUDE.md` prose instead, with the honest caveat that prose is
+  advisory. Revisit if a stale stack actually gets published.
+
+Deliberately **not** adopted in the same change: `gh skill install github/gh-stack --agent
+claude-code`, which drops a GitHub-authored skill into `~/.claude/skills/` — the same directory
+boom glob-links into. It is a new agent-context surface from outside the repo, and the doctrine is
+that those get enumerated before adoption, not installed as a side effect. Our own
+`agent-friendly-repo` skill now carries the repo-side guidance; if the CLI ergonomics turn out to
+need more, adopt it explicitly then.
+
 ---
 
 ## Branch protection

--- a/dot-claude/skills/agent-friendly-repo/SKILL.md
+++ b/dot-claude/skills/agent-friendly-repo/SKILL.md
@@ -34,14 +34,15 @@ dotFiles boomfile installs it (`gh extensions` section), so it should already be
 `gh extension install github/gh-stack` if not. Beware `gh ext search stack`: four community
 extensions share the name, and only `github/gh-stack` is the one GitHub ships.
 
-This checklist is already stack-compatible, and one item is *required* by stacks rather than
-merely preferred:
-- `required_linear_history` — `gh stack modify` refuses to restructure a stack whose history has
-  merge commits or diverged branches, so linear history is a precondition, not a taste.
-- `bypass_actors: []` — stack merges **cannot** bypass merge requirements at all (`gh stack merge`
-  says so outright). A repo whose agent path depends on bypass simply can't use stacks.
-- `allow_auto_merge=true` — auto-merge coexists with stacks: `gh stack unstack` deliberately
-  leaves a PR stacked when it is queued or has auto-merge enabled.
+This checklist is already stack-compatible, and **two of its items turn out to be preconditions**
+for stacks rather than merely preferred:
+- `required_linear_history` — **precondition.** `gh stack modify` refuses to restructure a stack
+  whose history has merge commits or diverged branches, so linear history is not a taste here.
+- `bypass_actors: []` — **precondition, from the other direction.** Stack merges **cannot** bypass
+  merge requirements at all (`gh stack merge` says so outright), so a repo whose agent path
+  depends on a bypass actor simply can't use stacks.
+- `allow_auto_merge=true` — compatible: auto-merge coexists with stacks, since `gh stack unstack`
+  deliberately leaves a PR stacked when it is queued or has auto-merge enabled.
 - Squash-only is fine — `gh stack merge --squash` picks the method per-merge, *unless* a merge
   queue is in play (below), where the queue chooses and any method flag is ignored with a warning.
 

--- a/dot-claude/skills/agent-friendly-repo/SKILL.md
+++ b/dot-claude/skills/agent-friendly-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-friendly-repo
-description: Make a GitHub repo agent-friendly for automated PR → auto-merge — squash-only merge settings, a single ruleset (linear history, non-fast-forward, one aggregate status check, no required human review, no bypass), and optionally a merge queue. Use when the user says "make this repo agent-friendly", "set up auto-merge", "align merge settings + branch protection", "add a merge queue", or bootstraps a repo and wants the agent completion path (`gh pr merge --auto`) to work. The executable version of the "Repository merge & branch-protection defaults" + "Agent worktree & merge workflow" sections in ~/.claude/CLAUDE.md.
+description: Make a GitHub repo agent-friendly for automated PR → auto-merge — squash-only merge settings, a single ruleset (linear history, non-fast-forward, one aggregate status check, no required human review, no bypass), stacked-PR support via the official `github/gh-stack` extension, and optionally a merge queue. Use when the user says "make this repo agent-friendly", "set up auto-merge", "align merge settings + branch protection", "add a merge queue", "set up stacked PRs", or bootstraps a repo and wants the agent completion path (`gh pr merge --auto`) to work. The executable version of the "Repository merge & branch-protection defaults" + "Agent worktree & merge workflow" sections in ~/.claude/CLAUDE.md.
 ---
 
 # agent-friendly-repo
@@ -26,6 +26,39 @@ Ruleset rules for the default branch:
 - `required_status_checks` → a **single aggregate gate job** (e.g. `quality-checks`), not every individual job. An aggregate `if: always()` job that `needs:` every other job and fails if any *actually failed* (path-filtered "skipped" jobs are fine) avoids "required check stuck pending" when per-area jobs are path-filtered out of a given PR.
 - **No required human PR reviews.** A required review blocks agent auto-merge forever — agents can't approve their own PRs. `--auto` waiting on green CI is the gate, not a human.
 - `bypass_actors: []` — nobody bypasses, incl. admins → "CI green for everyone" (the standing preference). Agents don't need bypass; `--auto` just waits for green.
+
+**Stacked PRs — the preferred shape for anything bigger than one reviewable change.**
+Standing preference: split a large change into a stack of small PRs, each based on the one below
+it, using the **official** `github/gh-stack` extension (public preview since 2026-07-30). The
+dotFiles boomfile installs it (`gh extensions` section), so it should already be on the machine —
+`gh extension install github/gh-stack` if not. Beware `gh ext search stack`: four community
+extensions share the name, and only `github/gh-stack` is the one GitHub ships.
+
+This checklist is already stack-compatible, and one item is *required* by stacks rather than
+merely preferred:
+- `required_linear_history` — `gh stack modify` refuses to restructure a stack whose history has
+  merge commits or diverged branches, so linear history is a precondition, not a taste.
+- `bypass_actors: []` — stack merges **cannot** bypass merge requirements at all (`gh stack merge`
+  says so outright). A repo whose agent path depends on bypass simply can't use stacks.
+- `allow_auto_merge=true` — auto-merge coexists with stacks: `gh stack unstack` deliberately
+  leaves a PR stacked when it is queued or has auto-merge enabled.
+- Squash-only is fine — `gh stack merge --squash` picks the method per-merge, *unless* a merge
+  queue is in play (below), where the queue chooses and any method flag is ignored with a warning.
+
+Stack-specific behavior worth knowing before recommending it:
+- `gh stack merge [<stack#>|<pr#>]` merges every PR up to and including the named one as a
+  **single all-or-nothing operation** — if any one can't merge, none do. Branch protection and
+  rulesets are evaluated by GitHub when the merge runs, so a red aggregate check fails the whole
+  batch, not just its layer.
+- **With a merge queue**, the stack is *added to the queue* rather than merged directly, and the
+  selected PRs "may land in separate groups rather than all at once" — so the all-or-nothing
+  guarantee above does **not** hold behind a queue. Queue support for stacks was still rolling
+  out at public preview; verify on the repo before promising it.
+- Local stack state lives in `.git/gh-stack` (untracked), so it is per-clone — an agent worktree
+  cut fresh does not inherit a stack. `gh stack checkout <stack#|pr#|url|branch>` re-attaches.
+- `delete_branch_on_merge` + stacks: not verified here. `gh stack sync` prunes merged branches
+  locally (`--prune` to skip the prompt); if a repo relies on server-side retargeting of child
+  PRs, confirm it on that repo rather than assuming.
 
 **Merge queue — the throughput unlock for parallel agents (optional, gated on CI support).**
 `strict` required-status-checks (require-branch-up-to-date-before-merge) *serializes* parallel PRs: each merge marks every other open PR out-of-date → forced rebase + full CI re-run per PR. A **merge queue** removes that churn while preserving "tested against latest main" (it tests each PR against the merged result). See the sequencing hazard below — enabling it before CI handles `merge_group` hangs every PR.
@@ -100,7 +133,7 @@ Ruleset rules for the default branch:
 
 8. **Merge queue (optional, only if the user wants it).** Follow the sequencing hazard below.
 
-9. **Report** the final state: merge settings, ruleset id + rules, whether classic was removed, aggregate-gate action taken, queue enabled or deferred (and why).
+9. **Report** the final state: merge settings, ruleset id + rules, whether classic was removed, aggregate-gate action taken, queue enabled or deferred (and why), and **stack readiness** — `gh extension list | grep github/gh-stack` for the tool, plus whether `required_linear_history` and empty `bypass_actors` hold (the two rules stacks actually require).
 
 ## Critical sequencing hazard — merge queue
 
@@ -118,4 +151,6 @@ Then agents complete with `gh pr merge --auto --squash`, which adds the PR to th
 - **`enforce_admins`/no-bypass = CI green for everyone, including alxjrvs.** For a genuine one-off emergency, disable+re-enable rather than weakening the default (delete the ruleset temporarily, or from a plain terminal). Don't add a standing bypass.
 - **Aggregate gate, not per-check requirements.** Requiring individual path-filtered jobs strands required checks in "pending". If you can't find/scaffold an aggregate job, stop and surface that — don't require the individual jobs as a fallback.
 - **Merge queue is opt-in and CI-gated.** Never add the `merge_queue` rule before the `merge_group:` trigger is on `main`. If CI has no `merge_group:` trigger, do the CI PR first (or defer the queue) — never enable it speculatively.
+- **Only `github/gh-stack`.** Never install a same-named community fork to satisfy "stacked PRs"; if the official extension is missing, install it or say so — don't substitute.
+- **Stacks are a workflow preference, not a repo mutation.** Nothing in this skill's write path enables them. Recommending stacks costs the repo nothing; the only repo-side facts are that `required_linear_history` and empty `bypass_actors` are prerequisites, and both are already on the checklist.
 - **Reference target:** SU-SRD PR #393 (the `merge_group` CI trigger + `changes` path-filter handling) and SU-SRD ruleset #9182849 are a known-good "after" state.


### PR DESCRIPTION
Makes stacked PRs the standing preference for agent work, and installs the tool that makes them executable.

## Why now

GitHub put stacked PRs into [public preview on 2026-07-30](https://github.blog/changelog/2026-07-30-stacked-pull-requests-are-now-in-public-preview/) with a first-party CLI extension. That is what changed the answer. Stacking was always the right shape for agent output — many small reviewable layers instead of one 40-file PR — but every prior implementation was a third-party tool (Graphite, `git-branchless`, four community `gh-stack` forks) with its own metadata model, hosted service, or both, and **native over special** ruled them all out. A GitHub-shipped extension that stores state in `.git/gh-stack` and drives the stock PR API *is* the stock behavior.

## What changed

- **`boomfile.toml`** — a new `gh extensions` section installs `github/gh-stack` install-if-absent.
  - It **must** sit after `packages`: `gh` comes from mise and sections run in file order, so a fresh machine has no `gh` on PATH before that.
  - The grep matches the `github/` owner deliberately — `gh ext search stack` returns four same-named community extensions and only one is GitHub's.
  - Imperative by necessity: `gh` has no declarative manifest and boom has no `gh` package manager (brew/mise/cargo/npm/pipx/gem/apt/dnf/flatpak only). Same shape as the existing Claude CLI install step. No `|| true` — a missing extension should fail loudly.
- **`agent-friendly-repo` skill** — stacked PRs added to the checklist and the completion path.
- **`dot-claude/CLAUDE.md`** — the workflow rule, folded into the standing merge preference.
- **`dot-claude/DECISIONS.md`** — the reasoning, per the contract/decision-record split.
- **`CLAUDE.md`** — gh extensions noted as the exception to the brew-vs-mise packaging policy.

## Two things that fell out of reading the tool's actual contract

- **The existing checklist was already a *precondition*, not merely compatible.** `gh stack modify` refuses a history with merge commits or diverged branches, and `gh stack merge` states outright that bypassing merge requirements is **not supported** for stack merges. So `required_linear_history` and `bypass_actors: []` — already in the skill on other grounds — are exactly what stacks need. A repo whose agent path leans on a bypass actor cannot use stacks at all.
- **The rebase-guard does not see `gh stack`.** It tokenizes for `git push` / `gh pr create` specifically, so `gh stack submit`/`push`/`sync` sail past it. Deliberately *not* fixed by widening the guard: `gh stack sync` already does fetch + cascading rebase + push natively, and re-deriving stack-aware behind-ness across N branches would duplicate that in security-relevant shell. The rule lives in prose, with the caveat that prose is advisory stated plainly.

Also flagged and **not** adopted here: `gh skill install github/gh-stack --agent claude-code` writes a GitHub-authored skill into `~/.claude/skills/` — the same directory boom glob-links into. That is a new agent-context surface from outside the repo, and the doctrine is that those get enumerated before adoption, not installed as a side effect.

## Verification

- `taplo check --no-schema` on all 7 tracked TOMLs — clean; section ordering asserted (`packages` idx 5 < `gh extensions` idx 6).
- `gitleaks detect` — no leaks.
- `dot-claude/hooks/tests/run.sh` — 33/33 guard regression tests pass.
- The `run` step was executed twice on this machine: installs `gh stack v0.1.0`, then no-ops (exit 0 both times).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LE5VUNcrTgBypsmYcD6doG