### PR TITLE
feat(ci): auto-merge Dependabot's minor/patch action bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot — github-actions only.
+#
+# This repo has no npm/bun manifest to update (boom is a binary, mise owns the
+# toolchains, brew owns the casks), so the pinned action tags in
+# .github/workflows/ are the entire dependency surface.
+#
+# minor+patch land grouped in one weekly PR, which .github/workflows/
+# dependabot-auto-merge.yml auto-merges once `lint` is green. Majors are
+# excluded from the group, so they arrive as individual PRs and stay manual —
+# an action major can change what code runs against a write-scoped token.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(actions)
+    groups:
+      actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,42 @@
+name: dependabot-auto-merge
+
+# Turns on GitHub's own auto-merge for Dependabot's grouped minor/patch action
+# bumps. It does not merge anything itself: `gh pr merge --auto` hands the PR to
+# GitHub, which waits for the required `lint` check exactly like an agent PR
+# does. Branch protection stays the gate; this only removes the human click.
+#
+# Why a workflow at all: there is no native "auto-merge Dependabot" switch —
+# dependabot.yml has no such key, and the per-PR auto-merge button needs a human.
+#
+# `on: pull_request` (never pull_request_target): Dependabot-triggered runs get a
+# read-only GITHUB_TOKEN by default but have respected the `permissions:` key
+# since Oct 2021, so plain pull_request suffices. pull_request_target would run
+# with a write token in base-branch context — unnecessary risk for a job that
+# never checks out the PR's code.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: meta
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # An explicit allowlist, not `!= major`: if update-type ever comes back
+      # empty (a metadata failure, a shape this action doesn't classify), a
+      # denylist would auto-merge it. This fails closed to a manual PR instead.
+      - name: Enable auto-merge (minor + patch only)
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Two new files plus the doc trail for them:

- `.github/dependabot.yml` — `github-actions` ecosystem only, weekly, minor+patch grouped into one PR. Majors are excluded from the group, so they arrive individually and stay manual.
- `.github/workflows/dependabot-auto-merge.yml` — one job, gated on `github.actor == 'dependabot[bot]'`, that calls `gh pr merge --auto --squash`. It merges nothing itself; `lint` + branch protection stay the gate.
- `agent-friendly-repo` skill — a new "Dependabot auto-merge" checklist block, procedure step 9, and a guardrail, so this is reusable rather than one-off.
- `dot-claude/CLAUDE.md` + `DECISIONS.md` — the rule and the why.

## Why a workflow at all

There is no native switch. `dependabot.yml` has no automerge key (Renovate does; Dependabot doesn't), and the per-PR auto-merge button needs a human click. What the agent-friendly checklist *already* provides is the precondition: **no required human review**, so a Dependabot PR needs nothing but a green aggregate check.

## The four constraints

| Constraint | Consequence if ignored |
|---|---|
| `on: pull_request`, not `pull_request_target` | Dependabot runs get a read-only token by default but have respected `permissions:` since Oct 2021 — `pull_request_target` would hand a write token to a base-context run for nothing |
| Actions secrets unavailable to Dependabot runs | A non-hermetic CI job fails every Dependabot PR and auto-merge silently never fires. `lint.yml` here is hermetic |
| `GITHUB_TOKEN` can't add a PR to a merge queue | This and the skill's optional merge-queue step are mutually exclusive without a PAT/App token |
| Allowlist (`== minor \|\| == patch`), never `!= major` | An empty `update-type` must fail closed to a manual PR, not auto-merge |

Majors stay manual on purpose: an action major changes what code runs against a write-scoped token, which is the supply-chain surface the *Standing threats* section exists to keep small.

## Verification

- Both YAML files parse; workflow shape confirmed (job `auto-merge`, correct `if`, `permissions: {contents: write, pull-requests: write}`).
- `biome check` clean, guard regression suite 33/33, gitleaks clean.
- The auto-merge path itself is unverified until Dependabot opens its first PR — nothing here can be exercised before then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TCXxDahKWEKqsAnuTCKTr