### PR TITLE
docs(stacks): auto-merge can't land a stack — fix the claim, make ship stack-aware

### DIFF
--- a/dot-claude/CLAUDE.md
+++ b/dot-claude/CLAUDE.md
@@ -89,6 +89,10 @@ Rules that apply whatever you are touching:
   classifier's own prescribed mechanism for letting background/unattended jobs land a finished
   PR. It authorizes `gh pr merge --auto` — GitHub's gated queue, which still waits on required
   checks — and does **not** loosen the "no direct `git` merge/push onto `main`" rule.
+  **It does not cover `gh stack merge`**, which is a different command and so an unenumerated
+  decision, not an oversight to be quietly fixed: unlike `--auto`, a queue-less `gh stack merge`
+  merges immediately rather than waiting for green. Adding `Bash(gh stack merge:*)` is the
+  open question; until it is answered, an unattended job submits a stack and hands it back.
 - **Worktree-checkout guard** — `PreToolUse` hook (matcher `Bash` →
   `~/.claude/hooks/worktree-checkout-guard.sh`, ordered *before* rebase-guard). Denies a
   `git checkout/switch <branch>` that would fail with "'<branch>' is already used by worktree".
@@ -160,12 +164,25 @@ overridden). Each agent gets `.claude/worktrees/<name>` on a **freshly created b
     `git push` / `gh pr create` specifically), so the guard is silent on them. That is not
     permission to publish a stale stack — `gh stack sync` (fetch + cascading rebase + push) is
     the stack-shaped version of the rebase-before-push rule, so run it first.
-  - `gh stack merge` merges every PR up to the chosen one all-or-nothing, and **cannot bypass**
-    merge requirements — so it needs `required_linear_history` and empty `bypass_actors`, which
-    the `agent-friendly-repo` checklist already sets. Behind a merge queue the stack is *queued*
-    instead, may land in separate groups, and merge-method flags are ignored.
+  - **A stack does not land via `gh pr merge --auto`.** GitHub: "Auto-merge is not supported for
+    stacked pull requests", and the legacy merge endpoint `gh pr merge` calls cannot merge a
+    stack at all. `gh stack merge [<stack#>|<pr#>]` (the Stacks API) is the only way — it merges
+    every PR up to the chosen one all-or-nothing and **cannot bypass** merge requirements, so it
+    needs `required_linear_history` and empty `bypass_actors`, which the `agent-friendly-repo`
+    checklist already sets. Never enable auto-merge on the bottom PR as a substitute: that lands
+    one layer and leaves the rest of the stack rebasing behind it.
+  - **Whether a stack can land *unattended* is a property of the repo, not the stack.** With a
+    merge queue, `gh stack merge` enqueues and the queue lands it once green (the stack may split
+    across groups, and merge-method flags are ignored) — that is the only fire-and-forget path.
+    Without a queue it merges *now*, checking only that each PR is open and non-draft, so a
+    pending or red check fails the whole batch. On a queue-less repo, an unattended job should
+    submit the stack and hand it back rather than merge speculatively.
+  - Checks are enforced **per PR against the stack's base branch**, so the default-branch ruleset
+    governs every layer — no intermediate PR is an unguarded hole, and a required human review
+    would block all of them.
   - Stack state lives in `.git/gh-stack` (untracked, per-clone), so a fresh agent worktree does
-    not inherit one — `gh stack checkout <stack#|pr#|url|branch>` re-attaches.
+    not inherit one — `gh stack checkout <stack#|pr#|url|branch>` re-attaches. Run `gh stack view`
+    before shipping: a branch that is stacked on GitHub can look unstacked locally.
 - **Rebase on the target before pushing.** Before the first `git push` / `gh pr create`:
   `git fetch origin && git rebase origin/<default>` (resolve conflicts; re-push with
   `--force-with-lease` if already pushed). `origin/HEAD` moves while an agent works, so even a
@@ -241,6 +258,12 @@ the recipes below are the reference it encodes.
   disable+re-enable the ruleset rather than adding a standing bypass. Find real check names via
   `gh api repos/<owner>/<repo>/commits/<branch>/check-runs --jq '.check_runs[].name'`.
   - The classic-protection fallback, for repos that cannot use rulesets, is in `DECISIONS.md`.
+- **Merge queue** — optional in general, but **required on any repo where agents should land
+  stacks unattended**, since `--auto` cannot merge a stack and `gh stack merge` doesn't wait for
+  green. It carries a `merge_group:` CI sequencing hazard (land the trigger on the default branch
+  *first*, or every PR hangs), which the `agent-friendly-repo` skill handles. It is also mutually
+  exclusive with the Dependabot auto-merge workflow — `GITHUB_TOKEN` cannot enqueue — so a repo
+  picks one: unattended stacks, or unattended Dependabot.
 - **Dependabot auto-merge** (opt-in, per repo): no required human review already unblocks it, but
   nothing fires `--auto` for the bot, so it takes a one-job workflow
   (`.github/workflows/dependabot-auto-merge.yml` here is the reference). `on: pull_request` with

--- a/dot-claude/DECISIONS.md
+++ b/dot-claude/DECISIONS.md
@@ -281,6 +281,61 @@ Two things fell out of reading the extension's actual contract rather than assum
   natively. The rule lives in `CLAUDE.md` prose instead, with the honest caveat that prose is
   advisory. Revisit if a stale stack actually gets published.
 
+### Correction: auto-merge does not land a stack, so the merge queue stopped being optional (2026-08-04)
+
+The adoption above shipped one wrong claim, and it was the load-bearing one. `agent-friendly-repo`
+listed `allow_auto_merge=true` as "compatible: auto-merge coexists with stacks", citing
+`gh stack unstack`'s note that GitHub "leaves stacked" a PR that is queued or has auto-merge
+enabled. That sentence is real, but it describes GitHub **refusing to unstack a PR with a pending
+merge intent** — it says nothing about auto-merge being able to *land* a stack. GitHub's docs say
+the opposite outright: "Auto-merge is not supported for stacked pull requests", and "the legacy
+pull request merge endpoints can't merge a stack" — which is precisely the endpoint `gh pr merge`
+calls. The error was inferring a capability from a tool's edge-case help text instead of reading
+the feature's own contract.
+
+Why it mattered rather than being a footnote: **`--auto` is the entire reason the agent completion
+path is unattended.** It waits for green. `gh stack merge` does not — it verifies only that each PR
+is open and non-draft, then asks GitHub to merge now, and a pending or red aggregate check fails
+the whole all-or-nothing batch. So "stacked PRs are the standing preference for agent work" and
+"agents complete work unattended" were quietly in conflict on every repo without a merge queue:
+the agent could build and submit a stack it had no way to land.
+
+The resolution is to stop treating the queue as a nicety. With a queue, `gh stack merge` *enqueues*
+and the queue lands the stack once checks pass — the only fire-and-forget path a stack has, and the
+true analogue of `--auto`. So the merge queue is now **optional in general, required for unattended
+stacks**, and the skill says which of the two modes a repo ended up in rather than reporting
+"stack-ready" flatly. The cost is honest and worth stating: the queue is mutually exclusive with
+the Dependabot auto-merge workflow (`GITHUB_TOKEN` can't enqueue), so a repo picks one unattended
+path or the other.
+
+Two further facts came from reading the feature contract rather than the CLI help, both of which
+cut *in favor* of the existing checklist:
+
+- **Checks are enforced per PR against the stack's base branch** — merging PR #3 of
+  `main ← #1 ← #2 ← #3` requires #1 and #2 to satisfy the base branch's required checks, reviews
+  and CODEOWNERS. So the default-branch ruleset already governs every layer; an intermediate PR is
+  not an unguarded hole. The mirror image is that a required human review blocks *all* layers,
+  which is another reason "no required human PR reviews" stays on the checklist.
+- **Queue support is complete, not partial.** The original entry hedged that it "was still rolling
+  out at public preview". It isn't: "Stacks fully support merge queues." The real caveats are
+  sizing — the queue lets a merge group exceed its configured maximum by up to 50% to keep a stack
+  together, splits a stack that still doesn't fit across consecutive groups, and ejects every PR
+  above one that leaves the queue.
+
+`ship` was stack-blind and is now stack-first. That was the sharpest edge of the same error: a
+stacked PR's base is the branch below it, so the skill's documented final step —
+`gh pr merge --auto --squash` — would have merged a layer **into its parent branch** rather than
+the default branch, collapsing the stack. It now runs `gh stack view` before anything else and
+branches to a `sync` → `submit` → `merge` pipeline, and on a queue-less repo it submits and hands
+back rather than merging speculatively.
+
+**`Bash(gh stack merge:*)` was deliberately not added to `permissions.allow`.** The existing
+`Bash(gh pr merge:*)` rule exists so unattended jobs can land finished work, and by that logic the
+stack equivalent belongs there too — but it is a different command with a different risk shape
+(queue-less, it merges N PRs immediately instead of waiting for green), and `CLAUDE.md`'s own rule
+is that settings get asked about, not added in passing. Left as an open question with the gap
+written into the contract, so an agent hits documented behavior rather than a silent denial.
+
 Deliberately **not** adopted in the same change: `gh skill install github/gh-stack --agent
 claude-code`, which drops a GitHub-authored skill into `~/.claude/skills/` — the same directory
 boom glob-links into. It is a new agent-context surface from outside the repo, and the doctrine is

--- a/dot-claude/skills/agent-friendly-repo/SKILL.md
+++ b/dot-claude/skills/agent-friendly-repo/SKILL.md
@@ -41,8 +41,23 @@ for stacks rather than merely preferred:
 - `bypass_actors: []` — **precondition, from the other direction.** Stack merges **cannot** bypass
   merge requirements at all (`gh stack merge` says so outright), so a repo whose agent path
   depends on a bypass actor simply can't use stacks.
-- `allow_auto_merge=true` — compatible: auto-merge coexists with stacks, since `gh stack unstack`
-  deliberately leaves a PR stacked when it is queued or has auto-merge enabled.
+- `allow_auto_merge=true` — **required for the ordinary path, but it cannot land a stack.**
+  GitHub's docs say it outright: "Auto-merge is not supported for stacked pull requests." A stack
+  lands only through the Stacks API — "the legacy pull request merge endpoints can't merge a
+  stack" — which is the endpoint `gh pr merge` calls. (`gh stack unstack`'s note that GitHub
+  "leaves stacked" a PR that is queued or has auto-merge enabled describes GitHub refusing to
+  *unstack* a PR with a pending merge intent. It is not evidence of an unattended completion
+  path, and reading it as one was this checklist's earlier error.)
+- **A merge queue is therefore not optional if stacks are to land unattended.** `gh pr merge
+  --auto` is the whole reason the ordinary agent path is fire-and-forget — it waits for green.
+  `gh stack merge` does **not** wait: it checks only that each PR is open and non-draft, then
+  asks GitHub to merge *now*, and a red or still-pending aggregate check fails the entire
+  all-or-nothing batch. The only wait-for-green equivalent for a stack is a **merge queue** —
+  with one configured, `gh stack merge` *enqueues* the stack and the queue lands it once checks
+  pass. Without a queue, an agent has to re-run `gh stack merge` after CI goes green, which is a
+  babysitting loop, not a completion path. So: recommending stacks on a repo is cheap;
+  recommending stacks *for unattended agent work* means recommending the queue with them, and
+  the queue carries the `merge_group:` sequencing hazard below.
 - Squash-only is fine — `gh stack merge --squash` picks the method per-merge, *unless* a merge
   queue is in play (below), where the queue chooses and any method flag is ignored with a warning.
 
@@ -53,8 +68,19 @@ Stack-specific behavior worth knowing before recommending it:
   batch, not just its layer.
 - **With a merge queue**, the stack is *added to the queue* rather than merged directly, and the
   selected PRs "may land in separate groups rather than all at once" — so the all-or-nothing
-  guarantee above does **not** hold behind a queue. Queue support for stacks was still rolling
-  out at public preview; verify on the repo before promising it.
+  guarantee above does **not** hold behind a queue. Queue support is otherwise complete, not
+  partial: "Stacks fully support merge queues. All pull requests in the stack are added to the
+  queue in the correct order." Two behaviors follow from that and are worth knowing before
+  sizing a stack — the queue "allows the merge group to exceed its configured maximum size by up
+  to 50 percent" to keep a stack together, and splits a stack that still doesn't fit across
+  consecutive merge groups; and "if a pull request is removed or ejected from the queue, all
+  pull requests above it in the stack are also removed", so one flaky layer ejects everything
+  above it.
+- Checks are enforced **per PR, against the stack's base branch**, not just on the bottom PR:
+  merging PR #3 of `main ← #1 ← #2 ← #3` requires #1 and #2 to satisfy the base branch's required
+  status checks, required reviews, and CODEOWNERS too. So the default-branch ruleset does govern
+  the whole stack — an intermediate PR is not an unguarded hole — and equally, a required human
+  review is fatal to *every* layer, not just the last.
 - Local stack state lives in `.git/gh-stack` (untracked), so it is per-clone — an agent worktree
   cut fresh does not inherit a stack. `gh stack checkout <stack#|pr#|url|branch>` re-attaches.
 - `delete_branch_on_merge` + stacks: not verified here. `gh stack sync` prunes merged branches
@@ -184,7 +210,11 @@ grouped PRs too.
    gh api -X DELETE repos/$o/$r/branches/$def/protection
    ```
 
-8. **Merge queue (optional, only if the user wants it).** Follow the sequencing hazard below.
+8. **Merge queue (optional in general — *required* if agents should land stacks unattended).**
+   Follow the sequencing hazard below. If the user wants stacked PRs as the default agent shape,
+   say up front that this step is the piece that makes it unattended: without a queue there is no
+   wait-for-green path for a stack, because `--auto` doesn't apply and `gh stack merge` merges
+   immediately or fails.
 
 9. **Dependabot auto-merge (optional, only if the user wants it).** Confirm the repo actually has
    a `.github/dependabot.yml` (if not, that's the first question — which ecosystems), that the
@@ -193,7 +223,7 @@ grouped PRs too.
    assuming it — `github-actions` bumps in particular change code that runs against a
    write-scoped token.
 
-10. **Report** the final state: merge settings, ruleset id + rules, whether classic was removed, aggregate-gate action taken, queue enabled or deferred (and why), and **stack readiness** — `gh extension list | grep github/gh-stack` for the tool, plus whether `required_linear_history` and empty `bypass_actors` hold (the two rules stacks actually require).
+10. **Report** the final state: merge settings, ruleset id + rules, whether classic was removed, aggregate-gate action taken, queue enabled or deferred (and why), and **stack readiness** — `gh extension list | grep github/gh-stack` for the tool, whether `required_linear_history` and empty `bypass_actors` hold (the two rules stacks actually require), and **whether a merge queue is configured**, since that is what decides if stacks can land unattended or only under supervision. State which of the two modes the repo ended up in rather than reporting "stack-ready" flatly.
 
 ## Critical sequencing hazard — merge queue
 
@@ -217,5 +247,6 @@ Then agents complete with `gh pr merge --auto --squash`, which adds the PR to th
   configure it alongside a merge queue without swapping `GITHUB_TOKEN` for a PAT/App token —
   `GITHUB_TOKEN` cannot add a PR to a queue.
 - **Only `github/gh-stack`.** Never install a same-named community fork to satisfy "stacked PRs"; if the official extension is missing, install it or say so — don't substitute.
-- **Stacks are a workflow preference, not a repo mutation.** Nothing in this skill's write path enables them. Recommending stacks costs the repo nothing; the only repo-side facts are that `required_linear_history` and empty `bypass_actors` are prerequisites, and both are already on the checklist.
+- **Stacks are mostly a workflow preference — with one repo-side exception.** Recommending stacks costs the repo nothing: `required_linear_history` and empty `bypass_actors` are their prerequisites and both are already on the checklist. But **unattended** stack landing does need a repo mutation, because `gh pr merge --auto` cannot land a stack and `gh stack merge` does not wait for green — so if the user wants agents to fire-and-forget a stack, the merge queue moves from optional to required, and step 8 stops being skippable. Say that plainly rather than implying stacks are free in every mode.
+- **Never claim auto-merge works on a stack.** It does not — GitHub says so explicitly, and the legacy merge endpoint `gh pr merge` calls cannot merge a stack at all. If a repo can't take a merge queue (e.g. it relies on the Dependabot auto-merge workflow, whose `GITHUB_TOKEN` can't enqueue), then on that repo stacks are an interactive workflow only; recommend them for human-driven work and keep unattended agent work on single PRs.
 - **Reference target:** SU-SRD PR #393 (the `merge_group` CI trigger + `changes` path-filter handling) and SU-SRD ruleset #9182849 are a known-good "after" state.

--- a/dot-claude/skills/ship/SKILL.md
+++ b/dot-claude/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Ship the current worktree — verify, commit, rebase, push, open a PR, and enable auto-merge — in one step. Use when work is done and the user says "ship it", "commit + push + PR", "open a PR and auto-merge", or otherwise asks to land the branch. Encodes alxjrvs's standard completion pipeline so it never has to be re-typed.
+description: Ship the current worktree — verify, commit, rebase, push, open a PR, and enable auto-merge — in one step, with a separate stack-aware path (`gh stack sync`/`submit`/`merge`) when the branch is part of a stacked PR. Use when work is done and the user says "ship it", "commit + push + PR", "open a PR and auto-merge", "land the stack", or otherwise asks to land the branch. Encodes alxjrvs's standard completion pipeline so it never has to be re-typed.
 ---
 
 # ship
@@ -8,6 +8,12 @@ description: Ship the current worktree — verify, commit, rebase, push, open a 
 The completion pipeline for a finished piece of work: **verify → commit → rebase → push → PR → auto-merge**. This is alxjrvs's documented standard (see `~/.claude/CLAUDE.md`, "Agent worktree & merge workflow"); running it as one skill replaces re-typing the steps every time.
 
 Never run this on `main`/`master` directly — the rebase-guard hook denies a direct push to the default branch, and that is correct. You must be on a feature branch in a worktree.
+
+## First: is this branch in a stack?
+
+Run `gh stack view` before anything else. If it reports a stack containing the current branch, **the steps below are the wrong pipeline** — jump to *Shipping a stack*. Getting this wrong is not cosmetic: a stacked PR's base is the branch below it, so `gh pr merge --auto --squash` would merge this layer **into its parent branch**, not into `main`, and silently collapse the stack.
+
+`gh stack view` exiting non-zero (or reporting no stack) means the ordinary path applies. Note that stack state lives in `.git/gh-stack`, which is untracked and per-clone — a freshly cut agent worktree never inherits one, so a branch that *is* part of a stack on GitHub can still look unstacked locally. If the branch was created by `gh stack add`, or the user has been talking about a stack, re-attach with `gh stack checkout <stack#|pr#|url|branch>` before deciding.
 
 ## Steps
 
@@ -38,8 +44,26 @@ Never run this on `main`/`master` directly — the rebase-guard hook denies a di
    ```
    Squash matches the repo default. **Do not add `-d`/`--delete-branch`** — that caused the #53 worktree-`main` collision (`gh` checks out `main` to delete the local branch, which the primary checkout already holds). The repos enable `delete_branch_on_merge`, so GitHub deletes the remote branch server-side; if a target repo doesn't, delete it manually *after* confirming the PR merged (`gh pr view --json state`), never right after an `--auto` merge on a not-yet-green PR. `--auto` waits for CI — it does **not** bypass required checks, and it is never a local `git merge`/`git push` onto `main`.
 
+## Shipping a stack
+
+Same first two steps — **verify** (step 1) and **commit** (step 2) on the current layer — then `gh stack` owns the rest, because it does the cascading rebase across every branch that steps 3–4 do for one:
+
+3. **Sync the stack**: `gh stack sync`. This fetches, fast-forwards trunk, cascade-rebases each branch onto its updated parent, and pushes them atomically (`--force-with-lease --atomic`). It is the stack-shaped form of the rebase-before-push rule — and it matters that you run it, because the rebase-guard tokenizes for `git push` / `gh pr create` and so **never fires on any `gh stack` command**. Nothing will stop you publishing a stale stack. If it reports a rebase conflict it restores every branch and tells you to run `gh stack rebase`; resolve there, don't force past it.
+
+4. **Submit**: `gh stack submit` pushes the branches and creates/updates one PR per branch, each based on the one below, then links them into a stack on GitHub. Non-interactively (or with `--auto`) it uses generated titles and creates PRs as **drafts** unless you pass `--open` — so for a stack meant to be reviewed, either write the titles interactively or pass `--open` deliberately.
+
+5. **Land it — and this is where the ordinary pipeline does not transfer.** `gh pr merge --auto` **cannot merge a stack**: GitHub's docs state "Auto-merge is not supported for stacked pull requests", and the legacy merge endpoint `gh pr merge` calls can't merge a stack at all. Use the Stacks API via `gh stack merge [<stack#>|<pr#>] --yes --squash`, which merges every PR up to and including the named one all-or-nothing.
+
+   Which mode you're in depends on the repo:
+   - **Merge queue configured** → `gh stack merge` *enqueues* the stack and the queue lands it once checks pass. This is the only fire-and-forget path for a stack, and the closest analogue to `--auto`. The queue picks the merge method, so `--squash` is ignored with a warning; large stacks may be split across consecutive merge groups, so the all-or-nothing guarantee weakens to per-group.
+   - **No merge queue** → `gh stack merge` asks GitHub to merge **now**. It only checks that each PR is open and non-draft; GitHub evaluates the rules at merge time, so a red or still-pending aggregate check fails the whole batch. **Do not run it speculatively on an unattended job.** Either stop after step 4 and report the stack for a human to land, or — if the user explicitly asked you to see it through — wait for checks (`gh pr checks <bottom-pr> --watch`) and merge once green.
+
+   Either way, never try to fake `--auto` by enabling auto-merge on the bottom PR and calling it done: that lands one layer into `main` and leaves the rest of the stack rebasing behind it.
+
 ## Guardrails
 
 - If required checks aren't configured on the repo, `--auto` may merge immediately — confirm the repo has branch protection before relying on it for unattended jobs.
+- **Check for a stack first, every time.** `gh pr merge --auto --squash` on a stacked PR merges it into its parent branch, not the default branch. This is the single most damaging way to misuse this skill.
+- **A stack on a queue-less repo has no unattended completion path.** Say so and hand back the stack rather than blocking on a wait loop or merging something that isn't green. If the user wants stacks to land unattended on that repo, the fix is the `agent-friendly-repo` skill's merge-queue step, not a workaround here.
 - If the user said "don't auto-merge" (they sometimes want to land something ahead of this branch), stop after step 5 and report the PR URL.
 - Report the PR URL and the final state (draft/ready, auto-merge enabled) when done.


### PR DESCRIPTION
Follow-up correction to #96.

## The error

#96 adopted `github/gh-stack` and recorded that `allow_auto_merge=true` was *"compatible: auto-merge coexists with stacks"*, inferred from `gh stack unstack` leaving a queued/auto-merge-enabled PR stacked. That sentence describes GitHub refusing to **unstack** a PR with a pending merge intent — it is not a completion path.

GitHub is explicit:

> Auto-merge is not supported for stacked pull requests.

> Merging a stacked pull request requires the Stacks API. The legacy pull request merge endpoints can't merge a stack.

...which is precisely the endpoint `gh pr merge` calls.

## Why it mattered

`--auto` is the entire reason the agent completion path is unattended: **it waits for green.** `gh stack merge` does not — it checks only that each PR is open and non-draft, then asks GitHub to merge *now*, so a pending or red aggregate check fails the whole all-or-nothing batch.

So "stacked PRs are the standing preference for agent work" and "agents complete work unattended" were quietly in conflict on every repo without a merge queue: an agent could build and submit a stack it had no way to land.

## Changes

- **`agent-friendly-repo`** — correct the claim. Promote the merge queue from *optional* to **required for unattended stacks**: with a queue, `gh stack merge` enqueues and the queue lands the stack once checks pass, which is the only true `--auto` analogue. Also records that checks are enforced **per PR against the stack's base branch** (so the default-branch ruleset governs every layer — no unguarded intermediate PR, but a required human review blocks all of them), and drops the stale "queue support still rolling out" hedge — it is complete, with sizing caveats instead.
- **`ship`** — was entirely stack-blind, the sharpest edge of the same error: a stacked PR's base is the branch below it, so the skill's documented final step `gh pr merge --auto --squash` would have merged a layer **into its parent branch** rather than `main`, collapsing the stack. Now runs `gh stack view` first and branches to a `sync` → `submit` → `merge` pipeline; on a queue-less repo it submits and hands the stack back rather than merging speculatively.
- **`CLAUDE.md` / `DECISIONS.md`** — the rules and the why.

## Deliberately not done

- **No `boomfile.toml` change.** The `gh extensions` section from #96 already installs `github/gh-stack`; nothing was missing there.
- **`Bash(gh stack merge:*)` NOT added to `permissions.allow`.** By the logic of the existing `Bash(gh pr merge:*)` rule it arguably belongs, but it is a different command with a different risk shape — queue-less, it merges N PRs immediately instead of waiting for green — and `CLAUDE.md`'s own rule is that settings get asked about, not added in passing. Left as an open question with the gap written into the contract, so an agent hits documented behavior rather than a silent denial.
- **No repo settings mutated.** Enabling a merge queue on this repo is an `agent-friendly-repo` action requiring explicit confirmation.

## Verification

Docs-only (4 markdown files). `gitleaks detect` clean; guard regression suite 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McAHTaUz2aHpGrkBtidvjH