### PR TITLE
fix(stacks): close the four gaps that left the stacked-PR path unexecutable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ The imperative residue the config can't express. A boom hook is a `hooks/<name>.
 Also NOT boom hooks — Claude Code hooks, linked into `~/.claude/hooks/`:
 
 - **`rebase-guard.sh` / `worktree-checkout-guard.sh`** — `PreToolUse` guards (see `dot-claude/CLAUDE.md`). They are the only deterministic enforcement in the setup.
-- **`pr-review.sh`** — `PostToolUse`: runs the adversarial review locally after `gh pr create` / `git push` and posts it as a PR review + a `claude-review` commit status. Backgrounds itself so it can never block a turn.
+- **`pr-review.sh`** — `PostToolUse`: runs the adversarial review locally after `gh pr create` / `git push` / `gh stack submit` and posts it as a PR review + a `claude-review` commit status. Backgrounds itself so it can never block a turn. The `gh stack submit` arm matches neither of the others (Stacks API + in-process push, so no `git push` Bash call), and covers the checked-out layer only.
 - **`hooks/tests/`** — `run.sh` + `cases.tsv`, a hermetic regression suite for the two guards (throwaway git fixtures in `$TMPDIR`, no network, <2s). Wired into `lint.yml` and lefthook pre-commit. **Add a case before changing a guard**: these are 200+ lines of security-relevant shell, and shipping them untested is how a `--dry-run` substring in an unrelated commit message came to disable the no-push-to-main rule.
 
 Small steps (`chmod 700 ~/.ssh`, `lefthook install`) are inline `run` (`on = "apply"`) entries, not files.
@@ -62,7 +62,7 @@ Small steps (`chmod 700 ~/.ssh`, `lefthook install`) are inline `run` (`on = "ap
 
 `Brewfile` holds **only** `mise` (bootstrap), casks (GUI apps, fonts), and system libs with no mise equivalent. `mise.toml` holds all language toolchains AND dev CLIs (`jq`, `shellcheck`, `shfmt`). If you're about to add a CLI to `Brewfile`, stop — it goes in `mise.toml` unless it's `mise` itself or a cask.
 
-**`gh` extensions are the one exception to both** — they aren't packages either manager knows about, and boom has no `gh` manager, so the `gh extensions` section carries install-if-absent `run` steps (today: the official `github/gh-stack`, for stacked PRs). That section **must stay after `packages`**: `gh` comes from mise and sections run in file order, so a fresh machine has no `gh` on PATH before it.
+**`gh` extensions are the one exception to both** — they aren't packages either manager knows about, and boom has no `gh` manager, so the `gh extensions` section carries install-if-absent `run` steps (today: the official `github/gh-stack` for stacked PRs, plus `dlvhdr/gh-dash`, `meiji163/gh-notify`, and `actions/gh-actions-cache`). Each grep is **owner-qualified** — `gh ext search stack` alone returns four same-named community forks, so a bare name is not an identity. That section **must stay after `packages`**: `gh` comes from mise and sections run in file order, so a fresh machine has no `gh` on PATH before it.
 
 ## Terminal: Ghostty (sole terminal)
 

--- a/boomfile.toml
+++ b/boomfile.toml
@@ -321,6 +321,28 @@ name = "gh extensions"
 on = "sync"
 cmd = "gh extension list | grep -q 'github/gh-stack' || gh extension install github/gh-stack"
 
+# The three below were installed by hand and went undeclared until 2026-08-04, so every fresh
+# machine came up without them — the exact drift this repo exists to prevent. Declared now
+# rather than uninstalled because each has a live consumer; drop any that stops earning it.
+#
+# Same shape as gh-stack: install-if-absent, no `|| true`, owner-qualified grep. These three are
+# community extensions (no official equivalent), which is why the owner in each grep matters at
+# least as much as it does for gh-stack.
+[[section.run]]
+on = "sync"
+# `gh dash` — the PR/issue dashboard. The one that makes a multi-repo agent backlog reviewable.
+cmd = "gh extension list | grep -q 'dlvhdr/gh-dash' || gh extension install dlvhdr/gh-dash"
+
+[[section.run]]
+on = "sync"
+# `gh notify` — GitHub notifications in the terminal.
+cmd = "gh extension list | grep -q 'meiji163/gh-notify' || gh extension install meiji163/gh-notify"
+
+[[section.run]]
+on = "sync"
+# `gh actions-cache` — inspect/evict Actions caches. Published by the `actions` org itself.
+cmd = "gh extension list | grep -q 'actions/gh-actions-cache' || gh extension install actions/gh-actions-cache"
+
 [[section]]
 name = "macOS defaults"
 

--- a/dot-claude/CLAUDE.md
+++ b/dot-claude/CLAUDE.md
@@ -89,10 +89,15 @@ Rules that apply whatever you are touching:
   classifier's own prescribed mechanism for letting background/unattended jobs land a finished
   PR. It authorizes `gh pr merge --auto` — GitHub's gated queue, which still waits on required
   checks — and does **not** loosen the "no direct `git` merge/push onto `main`" rule.
-  **It does not cover `gh stack merge`**, which is a different command and so an unenumerated
-  decision, not an oversight to be quietly fixed: unlike `--auto`, a queue-less `gh stack merge`
-  merges immediately rather than waiting for green. Adding `Bash(gh stack merge:*)` is the
-  open question; until it is answered, an unattended job submits a stack and hands it back.
+  `permissions.allow` also carries **`Bash(gh stack merge:*)`** (added 2026-08-04), for the same
+  reason applied to stacks: `gh pr merge` literally cannot merge a stack, so without this the
+  preferred shape for large agent work had no completion path at all. It is a **narrower**
+  authorization than it looks — stack merges cannot bypass merge requirements, so on a repo with
+  the `agent-friendly-repo` ruleset it can only land a stack GitHub already considers mergeable.
+  The real caveat is timing, not privilege: queue-less, it merges *now* rather than waiting for
+  green, so an unattended job on a queue-less repo submits the stack and hands it back instead of
+  merging speculatively. That restraint is `ship`'s rule, and it is prose — the permission does
+  not enforce it.
 - **Worktree-checkout guard** — `PreToolUse` hook (matcher `Bash` →
   `~/.claude/hooks/worktree-checkout-guard.sh`, ordered *before* rebase-guard). Denies a
   `git checkout/switch <branch>` that would fail with "'<branch>' is already used by worktree".
@@ -115,15 +120,20 @@ Rules that apply whatever you are touching:
     pre-commit): 33 hermetic cases against throwaway git fixtures, under 2s.
     **Add a case before changing a guard.**
 - **Recorded PR review (`PostToolUse`)** — `~/.claude/hooks/pr-review.sh` fires after
-  `gh pr create` / `git push`; when the repo is in `PR_REVIEW_REPOS` (a bare **owner**, covering
+  `gh pr create` / `git push` / **`gh stack submit`**; when the repo is in `PR_REVIEW_REPOS` (a bare **owner**, covering
   every repo under it, or a fully-qualified `owner/repo`; defaults to `TheGnarCo BinfiniteLLC
   SalvageUnion-io RANDSUM alxjrvs`) it runs the adversarial review locally and posts it as a real
   PR review plus a `claude-review` commit status. It backgrounds itself immediately so it can
   never block a turn, and a failed reviewer reports `success` with "review unavailable (not a
   verdict)" rather than masquerading as a clean bill of health. `if` is a field on an individual
-  hook handler, never on the matcher group — one rule per handler, so two commands means two
-  handlers. **Advisory until a day-30 finding rate justifies requiring it: above ~1 finding per
-  10 PRs that changed code, promote; below, delete it and close the question.**
+  hook handler, never on the matcher group — one rule per handler, so three commands means three
+  handlers. The `gh stack submit` arm exists because that command matches *neither* of the other
+  two — it creates PRs via the Stacks API and pushes inside the gh process, so no `git push` Bash
+  call ever reaches PostToolUse — which meant stacking silently routed the largest changes around
+  the reviewer. It reviews the **checked-out layer only**, not the whole stack, so a green
+  `claude-review` on one layer is not a verdict on the others. **Advisory until a day-30 finding
+  rate justifies requiring it: above ~1 finding per 10 PRs that changed code, promote; below,
+  delete it and close the question.**
 - **Spacebase MCP key** — `SPACEBASE_API_KEY_COMMAND` resolves the gnar `spacebase` plugin's key
   in-process via `op-agent secret op://…`. Paired with deliberately-empty `SPACEBASE_API_KEY` /
   `_URL` / `_PROJECT_ID` so the plugin's `${VAR}` pass-through resolves to `""` (server defaults)

--- a/dot-claude/DECISIONS.md
+++ b/dot-claude/DECISIONS.md
@@ -336,6 +336,48 @@ stack equivalent belongs there too — but it is a different command with a diff
 is that settings get asked about, not added in passing. Left as an open question with the gap
 written into the contract, so an agent hits documented behavior rather than a silent denial.
 
+### Closing the stack gaps: permission, reviewer, cascade, drift (2026-08-04)
+
+The correction above left the stacked-PR path documented but still not *executable*. Four gaps,
+found by asking of each existing mechanism "does `gh stack` match this?" — the answer was no every
+time, and each no was silent.
+
+- **`Bash(gh stack merge:*)` added to `permissions.allow`.** The previous entry deferred this as an
+  open question. It shouldn't have been: `gh pr merge` cannot merge a stack *at all*, so an
+  unattended job had no way to land one and the "preferred shape for agent work" was unreachable in
+  the mode that matters. It is narrower than it looks — stack merges cannot bypass merge
+  requirements, so under the `agent-friendly-repo` ruleset it can only land what GitHub already
+  considers mergeable. The genuine caveat is timing, not privilege: queue-less it merges *now*
+  instead of waiting for green. That restraint lives in `ship` as prose, and prose is advisory —
+  stated plainly rather than pretended away.
+- **The PR-review hook never fired on a stack.** Its trigger arms were `gh pr create` and
+  `git push`; `gh stack submit` matches neither, because it creates PRs through the Stacks API and
+  pushes *inside the gh process*, so no `git push` Bash call ever reaches `PostToolUse`. The whole
+  argument for that hook was that 1,113 org PRs went unreviewed — and adopting stacks would have
+  routed precisely the largest changes, the ones stacking exists for, around the reviewer. Fixed in
+  both places it has to be fixed (the settings.json `if` handler *and* the script's own belt-and-
+  braces `case` gate). Coverage is honestly partial: it resolves the PR for the checked-out branch,
+  so a submit reviews one layer, not the stack. Reviewing all N would mean N detached `claude -p`
+  runs per submit; each layer gets reviewed when it is the checked-out one instead.
+- **`rebase-prs` hand-rolled the cascade `gh stack sync` does natively.** It told the agent to
+  `git switch` each branch and rebase onto its parent — which is strictly worse than the tool:
+  it force-pushes branch by branch, so a failure midway leaves the stack half-rebased with children
+  on commits that no longer exist, and it cannot reconcile the stack object on GitHub. Straight
+  "native over special": the skill now peels stacks off to `gh stack sync` and keeps its loop for
+  genuinely independent PRs. This also removes the odd situation where the skill that inspired
+  adopting `gh stack` was still competing with it.
+- **Three `gh` extensions were installed by hand and undeclared** — `dlvhdr/gh-dash`,
+  `meiji163/gh-notify`, `actions/gh-actions-cache` — so every fresh machine came up without them.
+  Exactly the drift this repo exists to prevent, and it was invisible because the `gh extensions`
+  section existed and looked complete. Declared rather than uninstalled, since each has a live
+  consumer; the owner-qualified grep is the same discipline gh-stack needed.
+
+**Not** changed, having been checked rather than assumed: `gh stack` is at v0.1.0 and v0.1.0 *is*
+the latest release (2026-07-29), so the documented install-only/no-upgrade trap is not currently
+biting. The prior entry said to revisit "if the version actually drifts far enough to bite" — it
+hasn't, so adding an upgrade step or a version-drift check would be machinery for a hypothetical.
+Re-check when a v0.2 lands.
+
 Deliberately **not** adopted in the same change: `gh skill install github/gh-stack --agent
 claude-code`, which drops a GitHub-authored skill into `~/.claude/skills/` — the same directory
 boom glob-links into. It is a new agent-context surface from outside the repo, and the doctrine is

--- a/dot-claude/hooks/pr-review.sh
+++ b/dot-claude/hooks/pr-review.sh
@@ -38,8 +38,20 @@ exit_ok() { exit 0; }
 command -v jq > /dev/null 2>&1 || exit_ok
 input=$(cat 2> /dev/null) || exit_ok
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2> /dev/null) || exit_ok
+# `gh stack submit` is the stacked-PR equivalent of `gh pr create` + `git push`,
+# and matches NEITHER: it creates PRs through the Stacks API and pushes inside
+# the gh process, so no `git push` Bash call ever reaches PostToolUse. Without
+# this arm, adopting stacks would silently route the largest changes — the ones
+# stacking exists for — around the reviewer entirely.
+#
+# `gh stack sync` also pushes (force-with-lease, every branch) and is deliberately
+# NOT here. It is maintenance: a cascade-rebase onto a moved trunk replays the
+# same content under new SHAs, so firing on it would mean a full review per layer
+# every time trunk moves — cost without new signal, and the per-SHA lock can't
+# dedupe it because the rebase is what changes the SHA. Review on submit, when the
+# content is what changed.
 case "$cmd" in
-  *"gh pr create"* | *"git push"*) ;;
+  *"gh pr create"* | *"git push"* | *"gh stack submit"*) ;;
   *) exit_ok ;;
 esac
 
@@ -67,7 +79,13 @@ for entry in $PR_REVIEW_REPOS; do
 done
 [ "$allowed" = 1 ] || exit_ok
 
-# Only when there is an open PR for this branch.
+# Only when there is an open PR for this branch. NOTE for stacks: `gh stack
+# submit` creates/updates one PR per branch, but this resolves the PR for the
+# CHECKED-OUT branch only, so a submit reviews that one layer, not the whole
+# stack. That is partial coverage, deliberately — reviewing every layer would
+# mean N detached `claude -p` runs per submit, and each layer gets reviewed on
+# its own when it is the checked-out one. Don't read a green `claude-review`
+# status on one layer as a verdict on the stack.
 pr=$(gh pr view --json number -q .number 2> /dev/null) || exit_ok
 [ -n "$pr" ] || exit_ok
 

--- a/dot-claude/settings.json
+++ b/dot-claude/settings.json
@@ -30,7 +30,8 @@
   },
   "permissions": {
     "allow": [
-      "Bash(gh pr merge:*)"
+      "Bash(gh pr merge:*)",
+      "Bash(gh stack merge:*)"
     ],
     "deny": [
       "Bash(security find-generic-password:*)",
@@ -83,6 +84,11 @@
             "type": "command",
             "command": "~/.claude/hooks/pr-review.sh",
             "if": "Bash(git push:*)"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pr-review.sh",
+            "if": "Bash(gh stack submit:*)"
           }
         ]
       }

--- a/dot-claude/skills/rebase-prs/SKILL.md
+++ b/dot-claude/skills/rebase-prs/SKILL.md
@@ -1,11 +1,25 @@
 ---
 name: rebase-prs
-description: Rebase every open PR (or a named subset / a stack) in the current repo onto the fresh default branch and re-push. Use when the user says "rebase all open PRs against main", "get all my PRs up to date", "refresh the stack", or after the default branch has moved and several branches are behind. Automates a multi-PR fan-out alxjrvs does by hand.
+description: Rebase every open PR (or a named subset) in the current repo onto the fresh default branch and re-push; delegates stacked PRs to `gh stack sync` rather than walking them by hand. Use when the user says "rebase all open PRs against main", "get all my PRs up to date", "refresh the stack", or after the default branch has moved and several branches are behind. Automates a multi-PR fan-out alxjrvs does by hand.
 ---
 
 # rebase-prs
 
 Fan out the "rebase this branch onto fresh `main`" operation across many open PRs at once. Replaces manually walking each PR — the recurring "rebase all of them against main" request.
+
+## First: is the target a stack?
+
+If the branches in question are a **stack** (`gh stack view` reports one, or the user says "the stack"), **stop and use `gh stack sync`** — do not walk the branches by hand:
+
+```
+gh stack sync
+```
+
+That is the whole job for a stack, natively: it fetches, fast-forwards trunk, cascade-rebases each branch onto its *updated parent*, pushes them atomically (`--force-with-lease --atomic`), and re-syncs PR state. Hand-rolling the same cascade with per-branch `git switch` + `git rebase` is strictly worse — it force-pushes branch by branch (so a failure midway leaves the stack half-rebased, with children pointing at commits that no longer exist), and it can't reconcile the stack object on GitHub.
+
+On a rebase conflict `gh stack sync` restores every branch to its original state and tells you to run `gh stack rebase` — resolve there, then re-run sync. Don't fall back to the manual loop below to "get past" a conflict.
+
+The procedure below is for **independent** PRs that merely share a target. Use it when the branches are not a stack, or for the non-stack remainder alongside one.
 
 ## Procedure
 
@@ -19,12 +33,12 @@ Fan out the "rebase this branch onto fresh `main`" operation across many open PR
    ```
    gh pr list --state open --json number,headRefName,title,isDraft,mergeStateStatus
    ```
-   If the user named a subset (labels, a stack, specific numbers), filter to those. Note the ordering for a **stack**: rebase from the base of the stack upward so each branch rebases onto its already-updated parent, not stale commits.
+   If the user named a subset (labels, specific numbers), filter to those. If any of them turn out to be stacked, peel those off and hand them to `gh stack sync` per the section above rather than folding them into this loop.
 
 3. **For each branch, rebase onto the fresh target.** Do NOT `git checkout <default>` — in a worktree that fails ("already used by worktree"); the checkout-guard hook will block it anyway. Instead operate per branch:
    ```
    git fetch origin <branch> && git switch <branch>
-   git rebase origin/$def          # for a stack: rebase onto the parent branch instead of $def
+   git rebase origin/$def
    ```
    - **Conflicts:** stop on the first conflicted branch, resolve with full context, `git rebase --continue`, then carry on. Never `--skip` or blindly `-X theirs/ours`.
    - Re-push with lease: `git push --force-with-lease`.
@@ -36,6 +50,7 @@ Fan out the "rebase this branch onto fresh `main`" operation across many open PR
 ## Guardrails
 
 - Never touch `main`/`master` itself — only the PR branches.
+- **Never hand-roll a stack rebase.** `gh stack sync` is the native cascade; a per-branch loop force-pushes incrementally and can strand children on commits that no longer exist. If sync can't do it, `gh stack rebase` is the escape hatch — not this skill.
 - Isolation: if branches are checked out across multiple worktrees, rebase each in its own worktree rather than thrashing one checkout between branches.
 - Draft PRs are included by default; skip them only if asked.
 - Stop and surface any branch whose rebase you can't cleanly resolve — don't force through a bad merge.


### PR DESCRIPTION
Follow-up to #102. That PR documented how stacks work; this one makes them actually run.

Each gap was found by asking of every existing mechanism *"does `gh stack` match this?"* — the answer was **no** every time, and every no was silent.

## 1. `Bash(gh stack merge:*)` added to `permissions.allow`

#102 deferred this as an open question. It shouldn't have: `gh pr merge` **cannot merge a stack at all**, so an unattended job had no way to land one — the preferred shape for agent work was unreachable in exactly the mode that matters.

It's narrower than it looks. Stack merges cannot bypass merge requirements, so under the `agent-friendly-repo` ruleset it can only land a stack GitHub already considers mergeable. The real caveat is **timing, not privilege**: queue-less it merges *now* rather than waiting for green. That restraint lives in `ship` as prose, and prose is advisory — stated plainly rather than pretended away.

## 2. The PR-review hook never fired on a stack

Its trigger arms were `gh pr create` and `git push`. **`gh stack submit` matches neither** — it creates PRs through the Stacks API and pushes *inside the gh process*, so no `git push` Bash call ever reaches `PostToolUse`.

The entire argument for that hook was that 1,113 org PRs went unreviewed. Adopting stacks would have routed precisely the **largest** changes — the ones stacking exists for — around the reviewer.

Fixed in both places it has to be (the settings.json `if` handler *and* the script's own belt-and-braces `case` gate). Two honest limits, both documented in-line:
- Coverage is **partial**: it resolves the PR for the checked-out branch, so a submit reviews one layer, not the stack. Reviewing all N would mean N detached `claude -p` runs per submit.
- **`gh stack sync` is deliberately excluded.** It also force-pushes every branch, but a cascade-rebase replays the same content under new SHAs — firing on it means a full review per layer every time trunk moves. Cost without signal, and the per-SHA lock can't dedupe it because the rebase is what changes the SHA.

## 3. `rebase-prs` hand-rolled the cascade `gh stack sync` does natively

It instructed the agent to `git switch` each branch and rebase onto its parent — strictly worse than the tool: it force-pushes branch by branch, so a failure midway leaves the stack half-rebased with children pointing at commits that no longer exist, and it can't reconcile the stack object on GitHub. Straight *native over special*. Also resolves the oddity that the skill which motivated adopting `gh stack` was still competing with it.

## 4. Three `gh` extensions were installed by hand and undeclared

`dlvhdr/gh-dash`, `meiji163/gh-notify`, `actions/gh-actions-cache` — so **every fresh machine came up without them**. Exactly the drift this repo exists to prevent, and invisible because the `gh extensions` section existed and looked complete. Declared rather than uninstalled, since each has a live consumer.

## Checked, not assumed — and therefore *not* changed

`gh stack` is at v0.1.0, and v0.1.0 **is** the latest release (published 2026-07-29). The documented install-only/no-upgrade trap isn't biting yet. #96 said to revisit "if the version actually drifts far enough to bite" — it hasn't, so an upgrade step or version-drift check would be machinery for a hypothetical. Re-check when v0.2 lands.

## Verification

shellcheck + shfmt clean · biome clean · `jq` valid + all four settings.json content guardrails pass · taplo clean · gitleaks clean · **33/33** guard regression tests · new trigger gate tested against 7 command shapes (fires on `gh stack submit`/`gh pr create`/`git push`, skips `gh stack view`/`sync`/unrelated).

## Still open — your call, not mine

`dotFiles` runs **classic** branch protection (`lint`, strict) with **zero rulesets**, and has no merge queue. So stacks work here but only *supervised*. Enabling a queue would make them unattended — at the cost of the Dependabot auto-merge workflow from #97, since `GITHUB_TOKEN` can't enqueue. I did not touch repo settings; that's an `agent-friendly-repo` action needing explicit confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McAHTaUz2aHpGrkBtidvjH