### PR TITLE
chore(biome): keep only the config that actually diverges from biome's defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,10 @@ Symlinked individually into `~/.claude/` (the `Claude` section of the boomfile):
 - **The prompt is starship** (`starship.toml`); keep it minimal.
 - **Neovim is plugin-free** (single `nvim/init.lua`, native LSP, ≥0.11). No plugin manager, no distro.
 - **`link` semantics live in boom, not here** — this repo only *declares* links in the boomfile.
+- **`biome.json` carries only divergences from biome's defaults** — same discipline as `settings.json`. The lint rules are stock: there is no `rules` block, so it is biome's recommended set, and `linter.enabled` is omitted because it already defaults true (verified — omitting the block still catches `noDebugger`; only an explicit `false` disables it). `formatter.enabled` and `indentWidth: 2` were dropped for the same reason. The three keys that remain are each load-bearing, so don't "tidy" them away:
+  - `vcs.useIgnoreFile` — biome does **not** respect `.gitignore` by default. Without it, a bare `biome check` descends into `.claude/worktrees/`, which holds full copies of this repo.
+  - `formatter.indentStyle: "space"` — biome's default is **tab**. `useEditorconfig` defaults to *false*, so `.editorconfig` alone does not make biome agree with the rest of the repo.
+  - `overrides` → `dot-claude/settings.json` `expand: "always"` — stops biome and the Claude Code client rewriting that file past each other (see #91).
 
 ## Gotchas
 

--- a/biome.json
+++ b/biome.json
@@ -6,12 +6,7 @@
     "useIgnoreFile": true
   },
   "formatter": {
-    "enabled": true,
-    "indentStyle": "space",
-    "indentWidth": 2
-  },
-  "linter": {
-    "enabled": true
+    "indentStyle": "space"
   },
   "overrides": [
     {


### PR DESCRIPTION
Applies the `settings.json` discipline — *enumerate divergences, not defaults* — to `biome.json`. Three of its six keys were restating biome's own behaviour, which is worse than noise: it implies a decision was made where none was.

## The lint rules were already stock

There is no `rules` block, so the linter runs biome's **recommended** set, unmodified. Nothing to change there.

## Dropped — verified redundant, not assumed

| key | why it goes |
|---|---|
| `linter.enabled: true` | omitting the whole block still catches `lint/suspicious/noDebugger`; only an explicit `false` disables linting |
| `formatter.enabled: true` | defaults on |
| `formatter.indentWidth: 2` | 2 is already biome's default |

Probe results (biome 2.5.3):

```
linter block present, enabled:true | exit=1 | noDebugger hits=1
linter block omitted entirely      | exit=1 | noDebugger hits=1
linter explicitly disabled         | exit=1 | noDebugger hits=0
```

## Kept — each is load-bearing

I nearly removed these too, so the reasoning is now written into `CLAUDE.md` where the next tidy-up will find it:

- **`vcs.useIgnoreFile`** — biome does **not** respect `.gitignore` by default. Without it a bare `biome check` descends into `.claude/worktrees/`, which contains *full copies of this repo*.
- **`formatter.indentStyle: "space"`** — biome's default is **tab**, and `useEditorconfig` defaults to **false**, so `.editorconfig` alone does not make biome agree with the rest of the repo. Probe: a 2-space file is reformatted under `{}` *even with* `.editorconfig` present, and only goes clean with `indentStyle` set (or `useEditorconfig` explicitly on).
- **the `dot-claude/settings.json` `expand: "always"` override** — #91's fix for biome and the Claude Code client rewriting that file past each other.

## Verification

A/B against the real repo, old config vs new:

```
old config exit=0    Checked 4 files. No fixes applied.  (check + format)
new config exit=0    Checked 4 files. No fixes applied.  (check + format)
```

Identical scope, identical result — the only difference in the captured output was elapsed milliseconds.

## Possible follow-up, not done here

`formatter.indentStyle: "space"` duplicates a fact `.editorconfig` already states. Swapping it for `useEditorconfig: true` would leave one source of truth for indentation instead of two. I left it alone because it trades a self-contained lint config for an indirection you didn't ask for — say the word if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McAHTaUz2aHpGrkBtidvjH