### PR TITLE
docs(stacks): make stacks the default shape and decline the merge queue

### DIFF
--- a/dot-claude/CLAUDE.md
+++ b/dot-claude/CLAUDE.md
@@ -164,12 +164,25 @@ Claude Code isolates background/subagent work into git worktrees by default
 overridden). Each agent gets `.claude/worktrees/<name>` on a **freshly created branch** off
 `origin/<default-branch>`.
 
-- **Prefer a stack of small PRs over one large one**, via the **official** `github/gh-stack`
-  extension (`gh stack`, public preview since 2026-07-30) — installed by the dotFiles boomfile's
-  `gh extensions` section, never a same-named community fork. Reach for it when a change is
-  bigger than one reviewable PR: `gh stack init` → `gh stack add` per layer → `gh stack submit`
-  (one PR per branch, each based on the one below) → `gh stack sync` after a layer lands. It owns
-  the cascading rebase across the whole stack, which is the part that is miserable by hand.
+- **A stack of small PRs is the default shape for multi-part work**, via the **official**
+  `github/gh-stack` extension (`gh stack`, public preview since 2026-07-30) — installed by the
+  dotFiles boomfile's `gh extensions` section, never a same-named community fork.
+  `gh stack init` → `gh stack add` per layer → `gh stack submit` (one PR per branch, each based
+  on the one below) → `gh stack sync` after a layer lands. It owns the cascading rebase across
+  the whole stack, which is the part that is miserable by hand.
+  - **Decide the shape before writing code, not at ship time.** Once the work is one large
+    commit, splitting it is archaeology. If the plan has separable layers, cut the branches up
+    front — that is the entire ergonomic win, and it is unavailable retroactively.
+  - **What earns its own layer:** a change that could be reviewed, and reverted, on its own. In
+    practice that means a refactor that enables the feature (not the feature), a schema or type
+    change ahead of its consumers, a mechanical rename or move separated from behavior, or docs
+    separated from code. **What does not:** splitting by file, by commit count, or to hit a size
+    target. A layer nobody could review in isolation is not a layer.
+  - **Don't stack a single reviewable change.** A one-layer stack is a PR with extra ceremony.
+    The test is whether a reviewer would want the layers separately, not whether the diff is big.
+  - **Stacks are the default, not a mandate.** When work genuinely resists layering — a change
+    that is atomic by nature, or an urgent fix — ship one PR and say why in a sentence. Don't
+    manufacture layers to satisfy the rule.
   - `gh stack submit`/`push`/`sync` are **not** matched by the rebase-guard (which tokenizes for
     `git push` / `gh pr create` specifically), so the guard is silent on them. That is not
     permission to publish a stale stack — `gh stack sync` (fetch + cascading rebase + push) is
@@ -181,12 +194,14 @@ overridden). Each agent gets `.claude/worktrees/<name>` on a **freshly created b
     needs `required_linear_history` and empty `bypass_actors`, which the `agent-friendly-repo`
     checklist already sets. Never enable auto-merge on the bottom PR as a substitute: that lands
     one layer and leaves the rest of the stack rebasing behind it.
-  - **Whether a stack can land *unattended* is a property of the repo, not the stack.** With a
-    merge queue, `gh stack merge` enqueues and the queue lands it once green (the stack may split
-    across groups, and merge-method flags are ignored) — that is the only fire-and-forget path.
-    Without a queue it merges *now*, checking only that each PR is open and non-draft, so a
-    pending or red check fails the whole batch. On a queue-less repo, an unattended job should
-    submit the stack and hand it back rather than merge speculatively.
+  - **Land a stack by watching it green, then merging — no merge queue.** That trade is
+    deliberate (`DECISIONS.md`): a queue would buy fire-and-forget but is mutually exclusive with
+    the Dependabot auto-merge workflow, since `GITHUB_TOKEN` cannot enqueue. So the completion
+    path is `gh pr checks <pr> --watch` on **every** layer, then
+    `gh stack merge --yes --squash`. `gh stack merge` waits for nothing — it checks only that
+    each PR is open and non-draft, and GitHub evaluates the real rules at merge time, so firing
+    it at a pending stack just burns the attempt. If `main` moves while you wait, a `strict`
+    policy rejects the merge: `gh stack sync` and retry once, then report rather than loop.
   - Checks are enforced **per PR against the stack's base branch**, so the default-branch ruleset
     governs every layer — no intermediate PR is an unguarded hole, and a required human review
     would block all of them.
@@ -198,9 +213,14 @@ overridden). Each agent gets `.claude/worktrees/<name>` on a **freshly created b
   `--force-with-lease` if already pushed). `origin/HEAD` moves while an agent works, so even a
   branch cut from a fresh base can be behind by push time. Do this up front and the rebase-guard
   is a silent no-op; skip it and the guard blocks the push with this same instruction.
-- **Completion = commit → push → PR → auto-merge.** `gh pr merge --auto --squash` (never
-  `-d`/`--delete-branch`) is the way to land work — GitHub's gated queue, not a local
-  `git merge`/`git push` into the shared `main` checkout. `delete_branch_on_merge` is enabled
+- **Completion has two shapes, and the stack one is not a special case.**
+  - *Single PR*: commit → push → PR → `gh pr merge --auto --squash`. GitHub waits for green.
+  - *Stack*: `gh stack sync` → `gh stack submit` → watch **every** layer green
+    (`gh pr checks <pr> --watch`) → `gh stack merge --yes --squash`. Nothing waits for you here,
+    so the watch step is mandatory, not diligence.
+
+  Both end at GitHub's own gate; neither is ever a local `git merge`/`git push` into the shared
+  `main` checkout. Never `-d`/`--delete-branch`. `delete_branch_on_merge` is enabled
   repo-wide on `alxjrvs/dotFiles` and `alxjrvs/botu`; check `.delete_branch_on_merge` on any
   other repo the agent pushes to and enable it if false. Where it isn't enabled, delete the
   remote branch manually *after confirming the PR merged* (`gh pr view --json state`):
@@ -238,15 +258,15 @@ overridden). Each agent gets `.claude/worktrees/<name>` on a **freshly created b
 ## Repository merge & branch-protection defaults
 
 Standing preference for personal repos: **squash-only merges, rebase-preferred branch updates,
-linear history required, CI green before merging, and stacked PRs (`gh stack`) for anything
-bigger than one reviewable change.** Apply when setting up a new repo (e.g. via
+linear history required, CI green before merging, stacked PRs (`gh stack`) as the default shape
+for multi-part work, and no merge queue.** Apply when setting up a new repo (e.g. via
 `ignite:kickoff`) or when asked to align an existing one. This is a **per-repo,
 explicit-confirmation action**, not standing authorization to change settings unprompted.
 
 **The executable version is the `agent-friendly-repo` skill**
 (`dot-claude/skills/agent-friendly-repo/`) — it reads current state, diffs against the checklist,
-asks, then applies the merge settings + ruleset (and optionally a merge queue). Use the skill;
-the recipes below are the reference it encodes.
+asks, then applies the merge settings + ruleset. (It can still build a merge queue, but that step
+is skipped by default — see below.) Use the skill; the recipes below are the reference it encodes.
 
 - **Squash-only**: `gh api -X PATCH repos/<owner>/<repo> -F allow_squash_merge=true
   -F allow_merge_commit=false -F allow_rebase_merge=false`. Safe to combine with
@@ -268,12 +288,13 @@ the recipes below are the reference it encodes.
   disable+re-enable the ruleset rather than adding a standing bypass. Find real check names via
   `gh api repos/<owner>/<repo>/commits/<branch>/check-runs --jq '.check_runs[].name'`.
   - The classic-protection fallback, for repos that cannot use rulesets, is in `DECISIONS.md`.
-- **Merge queue** — optional in general, but **required on any repo where agents should land
-  stacks unattended**, since `--auto` cannot merge a stack and `gh stack merge` doesn't wait for
-  green. It carries a `merge_group:` CI sequencing hazard (land the trigger on the default branch
-  *first*, or every PR hangs), which the `agent-friendly-repo` skill handles. It is also mutually
-  exclusive with the Dependabot auto-merge workflow — `GITHUB_TOKEN` cannot enqueue — so a repo
-  picks one: unattended stacks, or unattended Dependabot.
+- **Merge queue — deliberately NOT used.** It is the only fire-and-forget path for a stack, but
+  it is mutually exclusive with the Dependabot auto-merge workflow (`GITHUB_TOKEN` cannot
+  enqueue) and it carries a `merge_group:` CI sequencing hazard that hangs every PR if the
+  trigger isn't on the default branch first. The call: keep Dependabot, land stacks by watching
+  them green and merging directly. **Don't propose a queue as the fix for having to wait** — the
+  waiting is the accepted cost. The `agent-friendly-repo` skill still knows how to set one up if
+  a repo ever justifies it.
 - **Dependabot auto-merge** (opt-in, per repo): no required human review already unblocks it, but
   nothing fires `--auto` for the bot, so it takes a one-job workflow
   (`.github/workflows/dependabot-auto-merge.yml` here is the reference). `on: pull_request` with

--- a/dot-claude/DECISIONS.md
+++ b/dot-claude/DECISIONS.md
@@ -378,6 +378,50 @@ biting. The prior entry said to revisit "if the version actually drifts far enou
 hasn't, so adding an upgrade step or a version-drift check would be machinery for a hypothetical.
 Re-check when a v0.2 lands.
 
+### Stacks become the default shape, and the merge queue is declined (2026-08-04)
+
+Owner's call, and it reverses the conclusion of the entry above. That entry argued the queue
+"stopped being optional" because `--auto` cannot land a stack and `gh stack merge` doesn't wait
+for green — so without a queue there was no fire-and-forget path. The facts are unchanged; the
+**decision** is that fire-and-forget was never worth its price here.
+
+What the queue actually costs on these repos:
+
+- **It is mutually exclusive with Dependabot auto-merge.** `GITHUB_TOKEN` cannot add a PR to a
+  merge queue, so enabling one silently breaks the workflow adopted in #97 — the thing that
+  removes a human click from every routine action bump. Trading a *daily* automation for an
+  *occasional* one is the wrong way round.
+- **It carries the `merge_group:` sequencing hazard.** Enable it before CI reports on the queue's
+  temp branches and every PR hangs forever. That is a real foot-gun standing between the repo and
+  a merge, permanently, in exchange for convenience on multi-layer changes.
+- **It weakens the guarantee stacks exist for.** Behind a queue a stack may be split across
+  consecutive merge groups, so the all-or-nothing property degrades to per-group.
+
+What "no queue" costs instead: the agent has to watch every layer to green before running
+`gh stack merge`. The earlier entry called that "a babysitting loop, not a completion path" —
+that framing was wrong, or at least overstated. `gh pr checks --watch` is a supported, bounded
+wait; the loop only becomes pathological if `main` moves faster than the stack can settle, which
+is a two-repo-contributor problem this repo does not have. The rule is therefore: sync, retry
+once, then report — never loop indefinitely.
+
+So the doctrine now reads: **stacks are the default shape for multi-part work; they land by
+watching green and merging directly; no queue.** `agent-friendly-repo` still knows how to build a
+queue, gated behind an explicit ask *and* a repo with no Dependabot auto-merge to lose.
+
+The other half of "lean in" is the part tooling can't do: **deciding the layers before writing
+the code.** Once work is one large commit, splitting it is archaeology, so `CLAUDE.md` now carries
+the decomposition test — a layer is something that could be reviewed and reverted on its own
+(an enabling refactor, a schema change ahead of its consumers, a mechanical rename, docs) and
+explicitly *not* a split by file, by commit count, or to hit a size target. With the honest
+counterweight attached: don't stack a single reviewable change, and don't manufacture layers to
+satisfy the rule. A one-layer stack is a PR with extra ceremony.
+
+Worth recording as evidence rather than principle: this doctrine was written across PRs #102 and
+#103, which were *themselves* stack-shaped — #103 built directly on #102's conclusions — and were
+shipped serially anyway, each waiting for the other to merge. The tooling wasn't live yet, which
+is a reason but not a good one. It is the clearest available measure of the gap between having
+the preference written down and actually reaching for it.
+
 Deliberately **not** adopted in the same change: `gh skill install github/gh-stack --agent
 claude-code`, which drops a GitHub-authored skill into `~/.claude/skills/` — the same directory
 boom glob-links into. It is a new agent-context surface from outside the repo, and the doctrine is

--- a/dot-claude/skills/agent-friendly-repo/SKILL.md
+++ b/dot-claude/skills/agent-friendly-repo/SKILL.md
@@ -48,18 +48,19 @@ for stacks rather than merely preferred:
   "leaves stacked" a PR that is queued or has auto-merge enabled describes GitHub refusing to
   *unstack* a PR with a pending merge intent. It is not evidence of an unattended completion
   path, and reading it as one was this checklist's earlier error.)
-- **A merge queue is therefore not optional if stacks are to land unattended.** `gh pr merge
-  --auto` is the whole reason the ordinary agent path is fire-and-forget — it waits for green.
-  `gh stack merge` does **not** wait: it checks only that each PR is open and non-draft, then
-  asks GitHub to merge *now*, and a red or still-pending aggregate check fails the entire
-  all-or-nothing batch. The only wait-for-green equivalent for a stack is a **merge queue** —
-  with one configured, `gh stack merge` *enqueues* the stack and the queue lands it once checks
-  pass. Without a queue, an agent has to re-run `gh stack merge` after CI goes green, which is a
-  babysitting loop, not a completion path. So: recommending stacks on a repo is cheap;
-  recommending stacks *for unattended agent work* means recommending the queue with them, and
-  the queue carries the `merge_group:` sequencing hazard below.
-- Squash-only is fine — `gh stack merge --squash` picks the method per-merge, *unless* a merge
-  queue is in play (below), where the queue chooses and any method flag is ignored with a warning.
+- **No merge queue — that is the house default, and it is a decision, not an omission.** A queue
+  is the only fire-and-forget path for a stack (`gh stack merge` *enqueues*, the queue lands it
+  when green). It was declined because it is mutually exclusive with the Dependabot auto-merge
+  workflow — `GITHUB_TOKEN` cannot add a PR to a queue — and because it carries the
+  `merge_group:` sequencing hazard below. The accepted cost is that `gh stack merge` does **not**
+  wait: it checks only that each PR is open and non-draft, then asks GitHub to merge *now*, and a
+  red or pending check fails the entire all-or-nothing batch. So the supported flow is
+  **watch every layer green (`gh pr checks <pr> --watch`), then merge** — see `ship`. Do not
+  recommend a queue as the remedy for that wait; recommend it only if a repo has no Dependabot
+  auto-merge to lose *and* the user asks.
+- Squash-only is fine — `gh stack merge --squash` gives one squashed commit per layer, which is
+  what preserves the layering in a linear history. (A queue, if one ever exists, picks the method
+  itself and ignores the flag with a warning.)
 
 Stack-specific behavior worth knowing before recommending it:
 - `gh stack merge [<stack#>|<pr#>]` merges every PR up to and including the named one as a
@@ -210,11 +211,11 @@ grouped PRs too.
    gh api -X DELETE repos/$o/$r/branches/$def/protection
    ```
 
-8. **Merge queue (optional in general — *required* if agents should land stacks unattended).**
-   Follow the sequencing hazard below. If the user wants stacked PRs as the default agent shape,
-   say up front that this step is the piece that makes it unattended: without a queue there is no
-   wait-for-green path for a stack, because `--auto` doesn't apply and `gh stack merge` merges
-   immediately or fails.
+8. **Merge queue — skip by default.** The standing decision is no queue: it would cost the
+   Dependabot auto-merge path (`GITHUB_TOKEN` can't enqueue), and stacks land fine by watching
+   them green and merging directly. Only do this step if the user explicitly asks *and* the repo
+   has no Dependabot auto-merge to lose — then follow the sequencing hazard below. Don't offer it
+   as the cure for "the agent has to wait for CI"; that wait is the accepted trade.
 
 9. **Dependabot auto-merge (optional, only if the user wants it).** Confirm the repo actually has
    a `.github/dependabot.yml` (if not, that's the first question — which ecosystems), that the
@@ -223,7 +224,7 @@ grouped PRs too.
    assuming it — `github-actions` bumps in particular change code that runs against a
    write-scoped token.
 
-10. **Report** the final state: merge settings, ruleset id + rules, whether classic was removed, aggregate-gate action taken, queue enabled or deferred (and why), and **stack readiness** — `gh extension list | grep github/gh-stack` for the tool, whether `required_linear_history` and empty `bypass_actors` hold (the two rules stacks actually require), and **whether a merge queue is configured**, since that is what decides if stacks can land unattended or only under supervision. State which of the two modes the repo ended up in rather than reporting "stack-ready" flatly.
+10. **Report** the final state: merge settings, ruleset id + rules, whether classic was removed, aggregate-gate action taken, queue enabled or deferred (and why), and **stack readiness** — `gh extension list | grep github/gh-stack` for the tool, whether `required_linear_history` and empty `bypass_actors` hold (the two rules stacks actually require), and that the landing path is watch-then-`gh stack merge` (no queue, by standing decision). If a queue *is* already configured on the repo, say so — it changes the merge semantics (enqueue instead of merge-now, method flags ignored, large stacks split across groups).
 
 ## Critical sequencing hazard — merge queue
 
@@ -247,6 +248,6 @@ Then agents complete with `gh pr merge --auto --squash`, which adds the PR to th
   configure it alongside a merge queue without swapping `GITHUB_TOKEN` for a PAT/App token —
   `GITHUB_TOKEN` cannot add a PR to a queue.
 - **Only `github/gh-stack`.** Never install a same-named community fork to satisfy "stacked PRs"; if the official extension is missing, install it or say so — don't substitute.
-- **Stacks are mostly a workflow preference — with one repo-side exception.** Recommending stacks costs the repo nothing: `required_linear_history` and empty `bypass_actors` are their prerequisites and both are already on the checklist. But **unattended** stack landing does need a repo mutation, because `gh pr merge --auto` cannot land a stack and `gh stack merge` does not wait for green — so if the user wants agents to fire-and-forget a stack, the merge queue moves from optional to required, and step 8 stops being skippable. Say that plainly rather than implying stacks are free in every mode.
-- **Never claim auto-merge works on a stack.** It does not — GitHub says so explicitly, and the legacy merge endpoint `gh pr merge` calls cannot merge a stack at all. If a repo can't take a merge queue (e.g. it relies on the Dependabot auto-merge workflow, whose `GITHUB_TOKEN` can't enqueue), then on that repo stacks are an interactive workflow only; recommend them for human-driven work and keep unattended agent work on single PRs.
+- **Stacks cost the repo nothing to enable.** `required_linear_history` and empty `bypass_actors` are their only prerequisites, and both are already on the checklist. There is no repo mutation to make stacks work — landing them is a *workflow* (watch green, then `gh stack merge`), which is why the queue is skippable.
+- **Never claim auto-merge works on a stack.** It does not — GitHub says so explicitly, and the legacy merge endpoint `gh pr merge` calls cannot merge a stack at all. The correct answer to "how does a stack land unattended, then" is: the agent watches every layer to green and runs `gh stack merge`, per the `ship` skill. It is not "add a merge queue."
 - **Reference target:** SU-SRD PR #393 (the `merge_group` CI trigger + `changes` path-filter handling) and SU-SRD ruleset #9182849 are a known-good "after" state.

--- a/dot-claude/skills/ship/SKILL.md
+++ b/dot-claude/skills/ship/SKILL.md
@@ -52,18 +52,31 @@ Same first two steps — **verify** (step 1) and **commit** (step 2) on the curr
 
 4. **Submit**: `gh stack submit` pushes the branches and creates/updates one PR per branch, each based on the one below, then links them into a stack on GitHub. Non-interactively (or with `--auto`) it uses generated titles and creates PRs as **drafts** unless you pass `--open` — so for a stack meant to be reviewed, either write the titles interactively or pass `--open` deliberately.
 
-5. **Land it — and this is where the ordinary pipeline does not transfer.** `gh pr merge --auto` **cannot merge a stack**: GitHub's docs state "Auto-merge is not supported for stacked pull requests", and the legacy merge endpoint `gh pr merge` calls can't merge a stack at all. Use the Stacks API via `gh stack merge [<stack#>|<pr#>] --yes --squash`, which merges every PR up to and including the named one all-or-nothing.
+5. **Land it — watch, then merge.** `gh pr merge --auto` **cannot merge a stack**: GitHub's docs state "Auto-merge is not supported for stacked pull requests", and the legacy merge endpoint `gh pr merge` calls can't merge a stack at all. The Stacks API is the only way in, and **the house default is to use it directly — no merge queue** (see `DECISIONS.md` for why that trade was taken).
 
-   Which mode you're in depends on the repo:
-   - **Merge queue configured** → `gh stack merge` *enqueues* the stack and the queue lands it once checks pass. This is the only fire-and-forget path for a stack, and the closest analogue to `--auto`. The queue picks the merge method, so `--squash` is ignored with a warning; large stacks may be split across consecutive merge groups, so the all-or-nothing guarantee weakens to per-group.
-   - **No merge queue** → `gh stack merge` asks GitHub to merge **now**. It only checks that each PR is open and non-draft; GitHub evaluates the rules at merge time, so a red or still-pending aggregate check fails the whole batch. **Do not run it speculatively on an unattended job.** Either stop after step 4 and report the stack for a human to land, or — if the user explicitly asked you to see it through — wait for checks (`gh pr checks <bottom-pr> --watch`) and merge once green.
+   Because `gh stack merge` does not wait for green, *you* do. The sequence is:
 
-   Either way, never try to fake `--auto` by enabling auto-merge on the bottom PR and calling it done: that lands one layer into `main` and leaves the rest of the stack rebasing behind it.
+   ```
+   gh pr checks <pr> --watch --fail-fast     # for EVERY layer, not just the bottom
+   gh stack merge --yes --squash             # atomic: all layers or none
+   ```
+
+   Four things make this correct rather than a hopeful loop:
+
+   - **Watch every layer.** `gh stack merge` is all-or-nothing and GitHub evaluates branch protection for *each* PR against the stack's base branch at merge time. One red layer fails the whole batch, so a green bottom PR proves nothing about the stack.
+   - **Re-sync if `main` moved while you waited.** Under a `strict` required-status-checks policy the merge is rejected when a branch is behind. That failure is expected, not exceptional: run `gh stack sync` and retry the merge. If you lose that race twice in a row, stop and report — something is landing faster than the stack can settle, and a third attempt won't fix it.
+   - **`--squash` gives one squashed commit per layer**, preserving the layering in `main`'s linear history. That is the point of stacking; don't collapse the stack into a single commit.
+   - **A merge failure is a report, not a retry-forever.** `gh stack merge` surfaces GitHub's own reason (red check, out-of-date branch, unsatisfied rule). Relay it verbatim rather than re-running blind.
+
+   Never fake `--auto` by enabling auto-merge on the bottom PR: that lands one layer into `main` and leaves the rest of the stack rebasing behind it.
+
+   If the user said "don't merge", stop after step 4 and report the stack — same rule as the single-PR path.
 
 ## Guardrails
 
 - If required checks aren't configured on the repo, `--auto` may merge immediately — confirm the repo has branch protection before relying on it for unattended jobs.
 - **Check for a stack first, every time.** `gh pr merge --auto --squash` on a stacked PR merges it into its parent branch, not the default branch. This is the single most damaging way to misuse this skill.
-- **A stack on a queue-less repo has no unattended completion path.** Say so and hand back the stack rather than blocking on a wait loop or merging something that isn't green. If the user wants stacks to land unattended on that repo, the fix is the `agent-friendly-repo` skill's merge-queue step, not a workaround here.
+- **Watching a stack to green is the completion path, not a workaround.** These repos deliberately run without a merge queue, so `gh pr checks --watch` on every layer followed by `gh stack merge` *is* the supported flow. Don't propose a merge queue as the fix for having to wait — that trade was considered and declined (`DECISIONS.md`).
+- **Never merge a stack you haven't watched to green.** `gh stack merge` checks only that each PR is open and non-draft; everything real is evaluated server-side at merge time. Firing it at a pending stack burns the attempt and reports a failure that looks like a bug.
 - If the user said "don't auto-merge" (they sometimes want to land something ahead of this branch), stop after step 5 and report the PR URL.
 - Report the PR URL and the final state (draft/ready, auto-merge enabled) when done.


### PR DESCRIPTION
Owner's call, and it **reverses #103's conclusion.** #102/#103 argued the merge queue "stopped being optional" because `--auto` cannot land a stack and `gh stack merge` doesn't wait for green. The facts are unchanged; the *decision* is that fire-and-forget was never worth its price here.

## What the queue actually costs

- **Mutually exclusive with Dependabot auto-merge.** `GITHUB_TOKEN` cannot add a PR to a merge queue, so enabling one silently breaks #97 — trading a *daily* automation for an *occasional* one. Wrong way round.
- **Carries the `merge_group:` sequencing hazard** — enable it before CI reports on the queue's temp branches and every PR hangs forever. A permanent foot-gun in exchange for convenience on multi-layer changes.
- **Degrades the guarantee stacks exist for** — a queued stack may be split across consecutive merge groups, so all-or-nothing weakens to per-group.

## What "no queue" costs, honestly

The agent watches every layer to green before merging. #103 called that *"a babysitting loop, not a completion path"* — that was overstated, and this PR retracts it. `gh pr checks --watch` is a bounded, supported wait. It only degenerates if `main` moves faster than the stack can settle, which is a many-contributor problem these repos don't have. Hence the explicit rule: **sync, retry once, then report** — never loop indefinitely.

## Changes

- **`ship`** — the stack path is now a real completion sequence (watch every layer → `gh stack merge --yes --squash`) instead of a hand-back. Documents *why* every layer must be watched (checks are enforced per-PR against the stack's base at merge time, so a green bottom PR proves nothing), the strict-policy re-sync retry, and that `--squash` yields one commit per layer — which is what preserves the layering in linear history.
- **`agent-friendly-repo`** — queue demoted to skip-by-default, gated behind an explicit ask *and* a repo with no Dependabot auto-merge to lose. Removes the "unattended stacks require a queue" claim throughout.
- **`CLAUDE.md`** — completion now has two documented shapes rather than one plus a caveat; the standing preference names stacks as the default and no-queue as deliberate.

## The half that tooling can't do

Leaning in isn't just having `gh stack` installed — it's **deciding the layers before writing the code**, because splitting one large commit afterwards is archaeology. `CLAUDE.md` now carries the test:

> a layer is something that could be reviewed, **and reverted**, on its own — an enabling refactor, a schema change ahead of its consumers, a mechanical rename, docs separated from code. Not a split by file, by commit count, or to hit a size target.

With the counterweight attached, so this doesn't produce silly 1-line stacks: **don't stack a single reviewable change** (a one-layer stack is a PR with extra ceremony), and don't manufacture layers to satisfy the rule.

## Eating it

**This PR is deliberately not a stack**, under that same rule — it's one reviewable change to one doctrine, and splitting it would be exactly the manufactured layering the rule warns against.

`DECISIONS.md` also records the uncomfortable evidence: #102 and #103 were *themselves* stack-shaped (#103 built directly on #102's conclusions) and were shipped serially anyway. That's the clearest measure available of the gap between writing the preference down and reaching for it.

## Verification

gitleaks clean · 33/33 guard tests · biome clean · grepped `ship` and `CLAUDE.md` for leftover contradictory merge-queue guidance (the two remaining mentions are the skill pointer and the Dependabot incompatibility note, both now consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McAHTaUz2aHpGrkBtidvjH