### PR TITLE
chore(gnar): use the canonical TheGnarCo casing for the agent-skills marketplace

### DIFF
--- a/dot-claude/CLAUDE.md
+++ b/dot-claude/CLAUDE.md
@@ -65,7 +65,7 @@ Rules that apply whatever you are touching:
   and per-subagent. **Fable must never be pinned as the default** — a drift check fails if it is
   (e.g. via `/model`'s "set as default", which rewrites this file).
 - **Plugins** — `enabledPlugins` runs two marketplaces:
-  - `extraKnownMarketplaces.gnar` → `thegnarco/agent-skills` (`autoUpdate`): `audit`, `ignite`,
+  - `extraKnownMarketplaces.gnar` → `TheGnarCo/agent-skills` (`autoUpdate`): `audit`, `ignite`,
     `spacebase`, `gninety`; plus `typescript-lsp`, `commit-commands`, `frontend-design`, `expo`
     from `claude-plugins-official`. No "must-install" set exists — each entry earns its place by
     use (`ideate`/`toolkit` deliberately off). Drop `expo` if the Expo work it serves stops.

--- a/dot-claude/settings.json
+++ b/dot-claude/settings.json
@@ -119,7 +119,7 @@
     "gnar": {
       "source": {
         "source": "github",
-        "repo": "thegnarco/agent-skills"
+        "repo": "TheGnarCo/agent-skills"
       },
       "autoUpdate": true
     },


### PR DESCRIPTION
Finishes what #95 started. That PR normalized every `claude-statusline` reference but left the two `agent-skills` ones, so the repo has been spelling the same org two ways.

GitHub confirms the canonical name:

```
gh api repos/thegnarco/agent-skills --jq .full_name
TheGnarCo/agent-skills
```

Two references, one string each — the `extraKnownMarketplaces.gnar` source in `settings.json`, and the matching enumeration line in `dot-claude/CLAUDE.md`. After this, `git grep thegnarco` returns nothing repo-wide.

## Why it's more than cosmetic

Same argument #95 made for the statusline hook. `~/.claude/plugins/known_marketplaces.json` caches the configured `source.repo` string alongside the checkout it produced:

```json
{ "source": { "source": "github", "repo": "thegnarco/agent-skills" },
  "installLocation": "~/.claude/plugins/marketplaces/gnar", "autoUpdate": true }
```

Any comparison of configured-vs-cached to decide whether to re-fetch then rests on the real name rather than on a GitHub redirect.

## Blast radius, by construction

The marketplace is keyed by **name** (`gnar`), and every `enabledPlugins` entry references `<plugin>@gnar` — `audit@gnar`, `ignite@gnar`, `spacebase@gnar`, `gninety@gnar`. None of them move. Only the fetch source is respelled.

Expect at most a one-time marketplace re-fetch: the same benign derived-state churn #95 predicted for the statusline, which `boom source` then did exactly as described (`upstream is now github.com/TheGnarCo/claude-statusline — re-cloning`).

## Verification

`jq` valid · all four `settings.json` content guardrails pass (no auto-approve MCP keys, git helper still `op-agent git-credential`, no `osxkeychain`, no Fable default) · biome clean · gitleaks clean · 33/33 guard tests · `git grep thegnarco` empty.

I'll confirm the marketplace still resolves on this machine after merging and pulling the config-repo.

Not a stack, per the rule landed in #106: this is one trivially reviewable change to one concern, and splitting it would be manufactured layering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McAHTaUz2aHpGrkBtidvjH