### PR TITLE
chore(telem): tag this repo's Claude Code telemetry with project.name

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "project.name=alxjrvs/dotFiles"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,16 @@ yarn-error.log*
 # user/global config lives in `dot-claude/`, symlinked into ~/.claude/ by
 # `boom apply`. (Repo-scoped only — global excludes live in `git/ignore`, NOT
 # a blanket `.claude/` that would hide it in every repo on the machine.)
-.claude/
+#
+# `.claude/*` rather than `.claude/` on purpose: git never descends into an
+# excluded *directory*, so a `!` negation inside one is silently inert. Ignoring
+# the contents instead is what lets the one exception below actually apply.
+.claude/*
+# The one tracked exception: telemetry attribution is a team-shared property of
+# the repo, not a machine-local preference, so `project.name` is checked in and
+# every clone emits the same tag with no per-member setup. `settings.local.json`
+# stays ignored (line below) and `worktrees/` stays ignored by `.claude/*`.
+!.claude/settings.json
 
 # Transient/generated
 Brewfile.lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Symlinked individually into `~/.claude/` (the `Claude` section of the boomfile):
 
 ## Gotchas
 
-- **dot-claude vs .claude**: `dot-claude/` is the source of truth for **user/global** Claude config (committed, symlinked into `~/.claude/`). The repo-root `.claude/` is this repo's **project-scoped**, gitignored config. Don't conflate them.
+- **dot-claude vs .claude**: `dot-claude/` is the source of truth for **user/global** Claude config (committed, symlinked into `~/.claude/`). The repo-root `.claude/` is this repo's **project-scoped** config, gitignored **except** the one tracked `.claude/settings.json` carrying the `project.name` telemetry tag — attribution is a property of the repo, not of a machine, so it is checked in rather than left to a per-clone `settings.local.json`. Don't conflate them.
 - **Sheldon plugin order**: `fast-syntax-highlighting` must be last in `sheldon/plugins.toml` (it wraps every existing ZLE widget at load).
 - **`gh` auth is keychain-backed**: token in the login keychain (gh secure storage); `~/.config/gh/hosts.yml` carries only non-secret metadata. Never `gh auth login --insecure-storage`.
 - **The engine is `boom`** (the BoomTube project): anything about apply/verify/fix/rollback semantics, symlink internals, the manifest/journal, or orphan reaping lives in `github.com/alxjrvs/boom`, not here. This repo is config.


### PR DESCRIPTION
## Why

gnar-telem groups COGS and spend by the `project.name` OTEL resource attribute. This repo emitted none, so its sessions landed in the `(untagged)` bucket — **18 of them**, the second-largest untagged source on this machine after `claude-statusline` (47).

## What

- `.claude/settings.json` (new, tracked) — `env.OTEL_RESOURCE_ATTRIBUTES = "project.name=alxjrvs/dotFiles"`.
- `.gitignore` — `.claude/` becomes `.claude/*` plus a `!.claude/settings.json` negation.
- `CLAUDE.md` — the "dot-claude vs .claude" gotcha said the repo-root `.claude/` is gitignored, which is now true only with an exception.

## Two decisions worth reviewing

**Tracked, not `settings.local.json`.** Telemetry attribution is a property of the repo, not of one machine — every clone should emit the same tag with no per-member setup. The user-level contract also forbids a local override layer outright ("*never a machine-local `settings.local.json`*"), so the local route was not actually available.

**`.claude/*` rather than `.claude/`.** Git never descends into an excluded *directory*, so a `!` negation inside one is silently inert — the file would have stayed invisible while the diff looked correct. Ignoring the contents instead is what makes the exception work. Verified: `settings.local.json` and `worktrees/` remain ignored, and `git status -uall` shows `.claude/settings.json` as the only newly-visible path.

## Not done here

`lefthook.yml`'s `settings-json-validity` still globs only `dot-claude/settings*.json`, so the new tracked file gets no JSON-validity gate. Its assertions are specific to the user-global file (op-agent git-credential wiring, the deny floor, the Fable pin) and would fail against a project-scoped file, so covering it needs a separate check rather than a wider glob. Left as a follow-up.

## Verification

`.gitignore` behavior verified per-path with `git check-ignore`; pre-commit hooks (gitleaks, biome) pass. The tag takes effect for sessions launched **after** this lands — already-running processes captured their resource attributes at launch and keep reporting `(untagged)` until restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)