### PR TITLE
fix(docs): gh-stack state is per worktree, not per clone

### DIFF
--- a/dot-claude/CLAUDE.md
+++ b/dot-claude/CLAUDE.md
@@ -299,9 +299,19 @@ overridden). Each agent gets `.claude/worktrees/<name>` on a **freshly created b
   - Checks are enforced **per PR against the stack's base branch**, so the default-branch ruleset
     governs every layer — no intermediate PR is an unguarded hole, and a required human review
     would block all of them.
-  - Stack state lives in `.git/gh-stack` (untracked, per-clone), so a fresh agent worktree does
-    not inherit one — `gh stack checkout <stack#|pr#|url|branch>` re-attaches. Run `gh stack view`
-    before shipping: a branch that is stacked on GitHub can look unstacked locally.
+  - Stack state lives in `.git/worktrees/<name>/gh-stack` for a linked worktree — untracked and
+    **per worktree, not per clone**, so two worktrees of one clone share none of it and a fresh
+    agent worktree inherits nothing. `gh stack checkout <stack#|pr#|url|branch>` re-attaches. Run
+    `gh stack view` before shipping: a branch that is stacked on GitHub can look unstacked locally.
+    Two further gotchas, both measured on 2026-08-15: `gh stack init` **requires** a branch
+    argument (the bare form dies on "interactive input required", which strands an unattended
+    agent), and it anchors the trunk to the **local** `main` ref rather than `origin/main` — so on
+    a machine where nobody checks out `main`, the persisted `trunk.head` can sit tens of commits
+    behind. `gh stack sync` cannot advance it either (git refuses to force-update a branch checked
+    out in another worktree, which it reports as a `fatal:` nested inside a warning on an
+    otherwise successful command). **Do not read `trunk.head` as truth, and do not "fix" that
+    warning** by removing the worktree or forcing the local ref — the tool falls back to
+    `origin/main`, which is the ref you wanted, and exits 0.
 - **Rebase on the target before pushing.** Before the first `git push` / `gh pr create`:
   `git fetch origin && git rebase origin/<default>` (resolve conflicts; re-push with
   `--force-with-lease` if already pushed). `origin/HEAD` moves while an agent works, so even a


### PR DESCRIPTION
The note at `dot-claude/CLAUDE.md:302` said stack state lives in `.git/gh-stack`, untracked and **per-clone**. It is `.git/worktrees/<name>/gh-stack`, and it is **per worktree** — two worktrees of one clone share none of it.

That distinction matters here specifically: nearly all agent work happens in linked worktrees, which is exactly the case the original note was written to warn about, and exactly the case it got wrong.

## How it was found

While running `gh stack` for real on `SalvageUnion-io/SU-SRD`. The agent doing the migration copied the per-clone claim **out of this file** into that repo's own `.claude/rules/stacked-prs.md`, then checked the actual path and corrected both — inside the file whose own rule says *don't write from memory what you can read from the source*.

Worth noting the shape: an inherited claim feels like knowledge and is actually a citation. This file was a source nobody had verified.

## Two further gotchas, both measured 2026-08-15

**`gh stack init` requires a branch argument.** The bare form exits on `interactive input required`. Survivable for a human; it strands an unattended agent with no operator to answer the prompt.

**`init` anchors the trunk to the LOCAL `main` ref, not `origin/main`.** On a machine where nobody ever checks out `main` — which is every machine running this setup — the persisted `trunk.head` was observed sitting **~40 commits behind** while the branch itself was correctly based on `origin/main`. `gh stack sync` cannot advance it either, because git refuses to force-update a branch checked out in another worktree, and it reports that as a `fatal:` nested inside a warning on a command that **exits 0**.

## Why that last one earns its place

The warning invites two "fixes", and both are worse than the message:

- **Removing the primary worktree** to silence it breaks every other session on that checkout.
- **Forcing the local ref** means forcing a ref that is deliberately checked out — the same class of mistake as a `--force` that resurrects a branch a squash-merge just deleted.

The tool already falls back to `origin/main`, which is the ref you wanted, and exits 0. So the note now says explicitly: don't read `trunk.head` as truth, and don't "fix" the warning.

Local checks: `biome check` clean, `gitleaks` no leaks, guard tests **71 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134EvKDdA1167vAeBoPpuf1
